### PR TITLE
Development refresh command(s).

### DIFF
--- a/.sites.config.example.yml
+++ b/.sites.config.example.yml
@@ -1,0 +1,12 @@
+---
+default:
+  database_s3_bucket: S3_BUCKET_NAME
+  theme_build:
+    - theme_path: web/themes/custom/theme1
+      theme_build_commands:
+        - yarn
+        - yarn build
+    - theme_path: web/themes/custom/theme2
+      theme_build_commands:
+        - yarn
+        - yarn build

--- a/.sites.config.yml
+++ b/.sites.config.yml
@@ -1,10 +1,10 @@
 ---
 default:
   theme_build:
-  - theme_path: src/Robo
-    theme_build_commands:
-      - pwd
-      - echo "This is where we pretend to build a theme!"
-  - theme_path: .github/
-    theme_build_commands:
-      - pwd
+    - theme_path: src/Robo
+      theme_build_commands:
+        - pwd
+        - echo "This is where we pretend to build a theme!"
+    - theme_path: .github/
+      theme_build_commands:
+        - pwd

--- a/.sites.config.yml
+++ b/.sites.config.yml
@@ -1,0 +1,10 @@
+---
+default:
+  theme_build:
+  - theme_path: src/Robo
+    theme_build_commands:
+      - pwd
+      - echo "This is where we pretend to build a theme!"
+  - theme_path: .github/
+    theme_build_commands:
+      - pwd

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ and can be extended in downstream repos.
 
 ## Configuration
 
-Create a `robo.yml` file in the root of your codebase. `robo.drupal.example.yml`
+1. Create a `robo.yml` file in the root of your codebase. `robo.drupal.example.yml`
 is provided as a starting point for Drupal projects.
-
-Add the following to your repo's `composer.json` "scripts" section so that you
+1. Create a `.sites.config.yml` file in the root of your codebase. See
+`.sites.config.example.yml` for reference on what can/should be configured.
+1. Add the following to your repo's `composer.json` "scripts" section so that you
 can call robo easily with `composer robo`:
 
 ```json

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "phpstan/phpstan": "^0.12.77",
         "phpstan/phpstan-deprecation-rules": "^0.12.6",
-        "drush/drush": "^10.4"
+        "drush/drush": "^10.4",
+        "async-aws/s3": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpstan/phpstan-deprecation-rules": "^0.12.6",
         "drush/drush": "^10.4",
         "async-aws/s3": "^1.8",
-        "php": "^7.4"
+        "php": ">=7.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "phpstan/phpstan": "^0.12.77",
         "phpstan/phpstan-deprecation-rules": "^0.12.6",
         "drush/drush": "^10.4",
-        "async-aws/s3": "^1.8"
+        "async-aws/s3": "^1.8",
+        "php": "^7.4"
     },
     "autoload": {
         "psr-4": {

--- a/robo.drupal.example.yml
+++ b/robo.drupal.example.yml
@@ -25,13 +25,3 @@ phpcs_ignore_paths:
 phpcs_standards:
   - Drupal
   - DrupalPractice
-database_s3_bucket: S3_BUCKET_NAME
-theme_build:
-  - theme_path: web/themes/custom/theme1
-    theme_build_commands:
-      - yarn
-      - yarn build
-  - theme_path: web/themes/custom/theme2
-    theme_build_commands:
-      - yarn
-      - yarn build

--- a/robo.drupal.example.yml
+++ b/robo.drupal.example.yml
@@ -25,6 +25,7 @@ phpcs_ignore_paths:
 phpcs_standards:
   - Drupal
   - DrupalPractice
+database_s3_bucket: S3_BUCKET_NAME
 theme_build:
   - theme_path: web/themes/custom/theme1
     theme_build_commands:

--- a/robo.yml
+++ b/robo.yml
@@ -11,11 +11,3 @@ phpcs_ignore_paths:
   - '*/themes/*/libraries/'
 phpcs_standards:
   - PSR12
-theme_build:
-  - theme_path: src/Robo
-    theme_build_commands:
-      - pwd
-      - echo "This is where we pretend to build a theme!"
-  - theme_path: .github/
-    theme_build_commands:
-      - pwd

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -113,13 +113,17 @@ class DevelopmentModeCommands extends Tasks
         $latestDatabaseDump = array_pop($objects);
         $dbFilename = $latestDatabaseDump->getKey();
 
-        $result = $s3->GetObject([
-            'Bucket' => $bucket,
-            'Key' => $dbFilename,
-        ]);
-        $fp = fopen($dbFilename, 'wb');
-        stream_copy_to_stream($result->getBody()->getContentAsResource(), $fp);
-        $this->say('Database dump file downloaded >>> ' . $dbFilename);
+        if (file_exists($dbFilename)) {
+            $this->say("Skipping download. Latest database dump file exists >>> $dbFilename");
+        } else {
+            $result = $s3->GetObject([
+                'Bucket' => $bucket,
+                'Key' => $dbFilename,
+            ]);
+            $fp = fopen($dbFilename, 'wb');
+            stream_copy_to_stream($result->getBody()->getContentAsResource(), $fp);
+            $this->say("Database dump file downloaded >>> $dbFilename");
+        }
         return $dbFilename;
     }
 

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -5,11 +5,11 @@ namespace ChqRobo\Robo\Plugin\Commands;
 use ChqRobo\Robo\Plugin\Traits\SitesConfigTrait;
 use AsyncAws\S3\S3Client;
 use DrupalFinder\DrupalFinder;
-use Drupal\Component\Serialization\Yaml;
 use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Robo;
 use Robo\Tasks;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Robo commands related to changing development modes.
@@ -216,7 +216,7 @@ class DevelopmentModeCommands extends Tasks
      */
     protected function landoUri($siteDir): string
     {
-        $landoConfig = Yaml::decode(file_get_contents('.lando.yml'));
+        $landoConfig = Yaml::parseFile('.lando.yml');
         $uri = $landoConfig['services']['appserver']['overrides']['environment']['DRUSH_OPTIONS_URI'] ?? null;
         if ($uri) {
             return $uri;
@@ -330,12 +330,12 @@ class DevelopmentModeCommands extends Tasks
             ->run();
 
         $this->say("enablig twig.debug in development.services.yml.");
-        $devServices = Yaml::decode(file_get_contents($this->devServicesPath));
+        $devServices = Yaml::parseFile($this->devServicesPath);
         $devServices['parameters']['twig.config'] = [
             'debug' => true,
             'auto_reload' => true,
         ];
-        file_put_contents($this->devServicesPath, Yaml::encode($devServices));
+        file_put_contents($this->devServicesPath, Yaml::dump($devServices));
 
         $this->say("disabling render and dynamic_page_cache in settings.local.php.");
         $result = $this->collectionBuilder()

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -66,13 +66,13 @@ class DevelopmentModeCommands extends Tasks
         $this->io()->title('development environment refresh. 🦄✨');
         $result = $this->taskComposerInstall()->run();
         $result = $this->taskExec('lando')->arg('start')->run();
-        $result = $this->databaseRefreshLando($siteName);
         // There isn't a great way to call a command in one class from another.
         // https://github.com/consolidation/Robo/issues/743
         // For now, it seems like calling robo from within robo works.
         $result = $this->taskExec("composer robo theme:build $siteName")
             ->run();
         $result = $this->frontendDevEnable($siteName, ['yes' => true]);
+        $result = $this->databaseRefreshLando($siteName);
         $result = $this->drupalLoginLink($siteName);
         return $result;
     }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -64,10 +64,15 @@ class DevelopmentModeCommands extends Tasks
      */
     public function devRefresh($siteName = 'default'): Result
     {
-        $this->io()->title('developer magic. 🦄');
-        $this->taskComposerInstall()->run();
-        $this->taskExec('lando')->arg('start')->run();
+        $this->io()->title('development environment refresh. 🦄✨');
+        $result = $this->taskComposerInstall()->run();
+        $result = $this->taskExec('lando')->arg('start')->run();
         $result = $this->databaseRefreshLando($siteName);
+        // There isn't a great way to call a command in one class from another.
+        // https://github.com/consolidation/Robo/issues/743
+        // For now, it seems like calling robo from within robo works.
+        $result = $this->taskExec('composer robo theme:build')
+            ->run();
         $result = $this->frontendDevEnable($siteName, ['yes' => true]);
         $result = $this->drupalLoginLink($siteName);
         return $result;

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -322,7 +322,6 @@ class DevelopmentModeCommands extends Tasks
     {
         $devSettingsPath = "$this->drupalRoot/sites/$siteDir/settings.local.php";
 
-        // @todo: undefined index when called with magic.
         if (!$opts['yes']) {
             $this->yell("This command will overwrite any customizations you have made to $devSettingsPath and
                 $this->devServicesPath.");

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace ChqRobo\Robo\Plugin\Commands;
+
+use AsyncAws\S3\S3Client;
+use DrupalFinder\DrupalFinder;
+use Drupal\Component\Serialization\Yaml;
+use Robo\Exception\TaskException;
+use Robo\Result;
+use Robo\Robo;
+use Robo\Tasks;
+
+/**
+ * Robo commands related to changing development modes.
+ */
+class DevelopmentModeCommands extends Tasks
+{
+
+    /**
+     * Drupal root directory.
+     *
+     * @var string
+     */
+    protected $drupalRoot;
+
+    /**
+     * Path to front-end development services path.
+     *
+     * @var string
+     */
+    protected $devServicesPath;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct()
+    {
+        // Treat this command like bash -e and exit as soon as there's a failure.
+        $this->stopOnFail();
+
+        // Find Drupal root path.
+        $drupalFinder = new DrupalFinder();
+        $drupalFinder->locateRoot(getcwd());
+        $this->drupalRoot = $drupalFinder->getDrupalRoot();
+        $this->devServicesPath = "$this->drupalRoot/sites/fe.development.services.yml";
+    }
+
+    /**
+     * Refreshes a development environment.
+     *
+     * Completely refreshes a development environment including running 'composer install', starting Lando, downloading
+     * a database dump, importing it, running 'drush deploy', disabling front-end caches, and providing a login link.
+     *
+     * @param string $siteDir
+     *   The Drupal site directory name.
+     *
+     * @aliases magic
+     *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     */
+    public function devRefresh($siteDir = 'default'): Result
+    {
+        $this->io()->title('developer magic. 🦄');
+        $this->taskComposerInstall()->run();
+        $this->taskExec('lando')->arg('start')->run();
+        $result = $this->databaseRefreshLando();
+        $result = $this->frontendDevEnable($siteDir, ['yes' => true]);
+        $result = $this->drupalLogin($siteDir);
+        return $result;
+    }
+
+    /**
+     * Download the latest database dump for the site.
+     *
+     * @return string
+     *   The path of the last downloaded database.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    public function databaseDownload()
+    {
+        $this->io()->title('database download.');
+
+        $awsConfigDirPath = getenv('HOME') . '/.aws';
+        $awsConfigFilePath = "$awsConfigDirPath/credentials";
+        if (!is_dir($awsConfigDirPath) || !file_exists($awsConfigFilePath)) {
+            $result = $this->configureAwsCredentials($awsConfigDirPath, $awsConfigFilePath);
+            if ($result->wasCancelled()) {
+                return Result::cancelled();
+            }
+        }
+
+        if (!$bucket = Robo::config()->get('database_s3_bucket')) {
+            throw new TaskException($this, 'database_s3_bucket value not set in robo.yml.');
+        }
+
+        $s3 = new S3Client();
+        $objects = $s3->listObjectsV2(['Bucket' => $bucket]);
+        $objects = iterator_to_array($objects);
+        // Ensure objects are sorted by last modified date.
+        usort($objects, fn($a, $b) => $a->getLastModified()->getTimestamp() <=> $b->getLastModified()->getTimestamp());
+        $latestDatabaseDump = array_pop($objects);
+        $dbFilename = $latestDatabaseDump->getKey();
+
+        $result = $s3->GetObject([
+            'Bucket' => $bucket,
+            'Key' => $dbFilename,
+        ]);
+        $fp = fopen($dbFilename, 'wb');
+        stream_copy_to_stream($result->getBody()->getContentAsResource(), $fp);
+        $this->say('Database dump file downloaded >>> ' . $dbFilename);
+        return $dbFilename;
+    }
+
+    /**
+     * Configure AWS credentials.
+     *
+     * @param string $awsConfigDirPath
+     *   Path to the AWS configuration directory.
+     * @param string $awsConfigFilePath
+     *   Path to the AWS configuration file.
+     */
+    protected function configureAwsCredentials(string $awsConfigDirPath, string $awsConfigFilePath)
+    {
+        $yes = $this->io()->confirm('AWS S3 credentials not detected. Do you wish to configure them?');
+        if (!$yes) {
+            return Result::cancelled();
+        }
+
+        if (!is_dir($awsConfigDirPath)) {
+            $this->_mkdir($awsConfigDirPath);
+        }
+
+        if (!file_exists($awsConfigFilePath)) {
+            $this->_touch($awsConfigFilePath);
+        }
+
+        $awsKeyId = $this->ask("AWS Access Key ID:");
+        $awsSecretKey = $this->askHidden("AWS Secret Access Key:");
+        return $this->taskWriteToFile($awsConfigFilePath)
+            ->line('[default]')
+            ->line("aws_access_key_id = $awsKeyId")
+            ->line("aws_secret_access_key = $awsSecretKey")
+            ->run();
+    }
+
+    /**
+     * Refresh a site database in Lando.
+     *
+     * @param array $opts
+     *   The options passed in.
+     *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     */
+    public function databaseRefreshLando(): Result
+    {
+        $this->io()->title('chq database refresh.');
+
+        $dbPath = $this->databaseDownload();
+
+        $this->io()->section('importing chq database.');
+        $this->say("Importing $dbPath");
+        $this->taskExec('lando')
+            ->arg('db-import')
+            ->arg($dbPath)
+            ->run();
+
+        $this->say("Deleting $dbPath");
+        $this->taskExec('rm')->args($dbPath)->run();
+        return $this->drushDeployLando();
+    }
+
+    /**
+     * Generate Drupal login link.
+     *
+     * @param string $siteDir
+     *   The Drupal site directory name.
+     * @param bool $lando
+     *   Use lando to call drush, else call drush directly.
+     *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     */
+    public function drupalLogin($siteDir = 'default', $lando = true): Result
+    {
+        $this->io()->section("create login link.");
+        if ($lando) {
+            $uri = $this->landoUri($siteDir);
+            $this->say("Lando URI detected: $uri");
+            return $this->taskExec('lando')
+                ->arg('drush')
+                ->arg('user:login')
+                ->option('--uri', $uri)
+                ->dir("web/sites/$siteDir")
+                ->run();
+        }
+        return $this->taskExec('../../../drush')
+            ->arg('user:login')
+            ->dir("web/sites/$siteDir")
+            ->run();
+    }
+
+    /**
+     * Detect Lando URI.
+     *
+     * @param string $siteDir
+     *   The Drupal site directory name.
+     *
+     * @return string
+     *   The Lando URI.
+     */
+    protected function landoUri($siteDir): string
+    {
+        $landoConfig = Yaml::decode(file_get_contents('.lando.yml'));
+        $uri = $landoConfig['services']['appserver']['overrides']['environment']['DRUSH_OPTIONS_URI'] ?? null;
+        if ($uri) {
+            return $uri;
+        } elseif (isset($landoConfig['proxy']['appserver'])) {
+            // Detect multi-site configurations.
+            $siteDomains = array_filter($landoConfig['proxy']['appserver'], function ($domain) {
+                if (strpos($domain, '$siteDir') !== false) {
+                    return true;
+                }
+            });
+            if (count($siteDomains > 1)) {
+                throw new TaskException($this, 'Unable to determine URI.');
+            } elseif (count($siteDomains == 1)) {
+                return array_pop($siteDomains);
+            }
+        } else {
+            // Our final fallback.
+            return 'http://' . $landoConfig['name'] . 'lndo.site';
+        }
+    }
+
+    /**
+     * Refresh database on Tugboat.
+     *
+     * @return null|\Robo\Result
+     *   The task result.
+     */
+    public function databaseRefreshTugboat(): Result
+    {
+        $this->io()->title('refresh tugboat databases.');
+        $dbPath = $this->databaseDownload();
+        if (empty($dbPath)) {
+            throw new TaskException($this, 'Database download failed.');
+        }
+
+        $result = $this->taskExec('mysql')
+            ->option('-h', 'mariadb')
+            ->option('-u', 'tugboat')
+            ->option('-ptugboat')
+            ->option('-e', 'drop database if exists tugboat; create database tugboat;')
+            ->run();
+
+        $this->io()->section('import chromatichq.com database.');
+        $result = $this->taskExec("zcat $dbPath | mysql -h mariadb -u tugboat -ptugboat tugboat")
+            ->run();
+        $this->taskExec('rm')->args($dbPath)->run();
+        return $result;
+    }
+
+    /**
+     * Deploy Drush via Lando.
+     *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     *
+     * @see https://www.drush.org/deploycommand
+     */
+    protected function drushDeployLando(): Result
+    {
+        $this->io()->section('drush deploy.');
+        return $this->taskExecStack()
+            ->dir('web/sites/default')
+            ->exec("lando drush deploy --yes")
+            // Import the latest configuration again. This includes the latest
+            // configuration_split configuration. Importing this twice ensures that
+            // the latter command enables and disables modules based upon the most up
+            // to date configuration. Additional information and discussion can be
+            // found here:
+            // https://github.com/drush-ops/drush/issues/2449#issuecomment-708655673
+            ->exec("lando drush config:import --yes")
+            ->run();
+    }
+
+    /**
+     * Enable front-end development mode.
+     *
+     * @param string $siteDir
+     *   The Drupal site directory name.
+     * @param array $opts
+     *   The options.
+     *
+     * @option boolean $yes Default answers to yes.
+     * @aliases fede
+     *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     */
+    public function frontendDevEnable($siteDir = 'default', array $opts = ['yes|y' => false])
+    {
+        $devSettingsPath = "$this->drupalRoot/sites/$siteDir/settings.local.php";
+
+        // @todo: undefined index when called with magic.
+        if (!$opts['yes']) {
+            $this->yell("This command will overwrite any customizations you have made to $devSettingsPath and
+                $this->devServicesPath.");
+            $yes = $this->io()->confirm('This command is destructive. Do you wish to continue?');
+            if (!$yes) {
+                return Result::cancelled();
+            }
+        }
+
+        $this->io()->title('enabling front-end development mode.');
+        $this->say("copying settings.local.php and development.services.yml into sites/$siteDir.");
+
+        $result = $this->taskFilesystemStack()
+            ->copy("$this->drupalRoot/sites/example.settings.local.php", $devSettingsPath, true)
+            ->copy("$this->drupalRoot/sites/development.services.yml", $this->devServicesPath, true)
+            ->run();
+
+        $this->say("enablig twig.debug in development.services.yml.");
+        $devServices = Yaml::decode(file_get_contents($this->devServicesPath));
+        $devServices['parameters']['twig.config'] = [
+            'debug' => true,
+            'auto_reload' => true,
+        ];
+        file_put_contents($this->devServicesPath, Yaml::encode($devServices));
+
+        $this->say("disabling render and dynamic_page_cache in settings.local.php.");
+        $result = $this->collectionBuilder()
+            ->taskReplaceInFile($devSettingsPath)
+            ->from('/sites/development.services.yml')
+            ->to("/sites/fe.development.services.yml")
+            ->taskReplaceInFile($devSettingsPath)
+            ->from('# $settings[\'cache\'][\'bins\'][\'render\']')
+            ->to('$settings[\'cache\'][\'bins\'][\'render\']')
+            ->taskReplaceInFile($devSettingsPath)
+            ->from('# $settings[\'cache\'][\'bins\'][\'dynamic_page_cache\'] = ')
+            ->to('$settings[\'cache\'][\'bins\'][\'dynamic_page_cache\'] = ')
+            ->taskReplaceInFile($devSettingsPath)
+            ->from('# $settings[\'cache\'][\'bins\'][\'page\'] = ')
+            ->to('$settings[\'cache\'][\'bins\'][\'page\'] = ')
+            ->run();
+        return $result;
+    }
+
+    /**
+     * Disable front-end development mode.
+     *
+     * @param string $siteDir
+     *   The Drupal site directory name.
+     * @param array $opts
+     *   The options.
+     *
+     * @option boolean $yes Default answers to yes.
+     * @aliases fedd
+     *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     */
+    public function frontendDevDisable($siteDir = 'default', array $opts = ['yes|y' => false])
+    {
+        $devSettingsPath = "$this->drupalRoot/sites/$siteDir/settings.local.php";
+        if (!$opts['yes']) {
+            $this->yell("This command will overwrite any customizations you have made to $devSettingsPath and
+                $this->devServicesPath.");
+            $yes = $this->io()->confirm('This command is destructive. Do you wish to continue?');
+            if (!$yes) {
+                return Result::cancelled();
+            }
+        }
+
+        $this->io()->title('disabling front-end development mode.');
+        return $this->collectionBuilder()
+            ->taskFilesystemStack()
+            ->remove($devSettingsPath)
+            ->remove($this->devServicesPath)
+            ->run();
+    }
+}

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -70,7 +70,7 @@ class DevelopmentModeCommands extends Tasks
         // There isn't a great way to call a command in one class from another.
         // https://github.com/consolidation/Robo/issues/743
         // For now, it seems like calling robo from within robo works.
-        $result = $this->taskExec('composer robo theme:build')
+        $result = $this->taskExec("composer robo theme:build $siteName")
             ->run();
         $result = $this->frontendDevEnable($siteName, ['yes' => true]);
         $result = $this->drupalLoginLink($siteName);

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -16,7 +16,6 @@ use Symfony\Component\Yaml\Yaml;
  */
 class DevelopmentModeCommands extends Tasks
 {
-
     use SitesConfigTrait;
 
     /**

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -243,11 +243,8 @@ class DevelopmentModeCommands extends Tasks
                 );
             }
             // Detect multi-site configurations.
-            $siteDomains = array_filter($landoCfg['proxy']['appserver'], function ($domain) use ($siteDir) {
-                if (strpos($domain, $siteDir) !== false) {
-                    return true;
-                }
-            });
+            $siteDomains = array_filter($landoCfg['proxy']['appserver'], fn($domain) =>
+                strpos($domain, $siteDir) !== false);
             if (count($siteDomains) > 1) {
                 throw new TaskException($this, 'More than one possible URI found.');
             } elseif (count($siteDomains) == 1) {

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -246,7 +246,7 @@ class DevelopmentModeCommands extends Tasks
             $siteDomains = array_filter($landoCfg['proxy']['appserver'], fn($domain) =>
                 strpos($domain, $siteDir) !== false);
             if (count($siteDomains) > 1) {
-                throw new TaskException($this, 'More than one possible URI found.');
+                $this->say('More than one possible URI found in Lando config >>> ' . implode(' | ', $siteDomains));
             } elseif (count($siteDomains) == 1) {
                 $domain = array_pop($siteDomains);
                 return "http://$domain";

--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -35,11 +35,8 @@ class ThemeCommands extends Tasks
      */
     public function themeBuild($siteName = 'default'): Result
     {
-        $sitesConfig = $this->getSiteConfig($siteName);
-        if (empty($themeBuildConfiguration = $sitesConfig['theme_build'])) {
-            throw new TaskException($this, "Expected theme configuration not present for $siteName.");
-        }
-        $this->io()->title("building themes");
+        $themeBuildConfiguration = $this->themeBuildConfiguration($siteName);
+        $this->io()->title("theme build");
         foreach ($themeBuildConfiguration as $themeConfig) {
             $themePath = $themeConfig['theme_path'];
             $this->io()->section("building theme at $themePath");
@@ -50,5 +47,38 @@ class ThemeCommands extends Tasks
             }
         }
         return $result;
+    }
+
+    /**
+     * Get theme build configuration with fallback.
+     *
+     * Retrieves theme_build configuration for a specified site. If the theme_build config is not
+     * present for the specified site, fall back to theme_build for 'default' if that is present.
+     *
+     * @return array
+     *   The theme_build configuration array.
+     */
+    protected function themeBuildConfiguration($siteName = 'default'): array
+    {
+        $siteConfig = $this->getSiteConfig($siteName);
+        $themeBuildConfiguration = $siteConfig['theme_build'] ?? null;
+        // @todo: Re-evaluate this fallback code. It's gross. All it does is reduce duplication
+        // in the sites config file. Is that worth this complexity?
+        if (empty($themeBuildConfiguration)) {
+            $defautConfig = $this->getSiteConfig('default');
+            $themeBuildConfiguration = $defautConfig['theme_build'] ?? null;
+            if (empty($themeBuildConfiguration)) {
+                throw new TaskException($this, "Expected theme configuration not present for $siteName.");
+            }
+            foreach($themeBuildConfiguration as $key => $steps) {
+                $placeholder = Robo::config()->get('sitename_placeholder');
+                if (strpos($steps['theme_path'], $placeholder) !== false) {
+                    $themeBuildConfiguration[$key]['theme_path'] = str_replace($placeholder, $siteName, $themeBuildConfiguration[$key]['theme_path']);
+                }
+            }
+            $this->say("Custom theme_build configuration not present for $siteName.
+            Falling back to configuration found in 'default'.");
+        }
+        return $themeBuildConfiguration;
     }
 }

--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -35,7 +35,7 @@ class ThemeCommands extends Tasks
      */
     public function themeBuild($siteName = 'default'): Result
     {
-        $themeBuildConfiguration = $this->themeBuildConfiguration($siteName);
+        $themeBuildConfiguration = $this->getConfig('theme_build', $siteName);
         $this->io()->title("theme build");
         foreach ($themeBuildConfiguration as $themeConfig) {
             $themePath = $themeConfig['theme_path'];
@@ -47,38 +47,5 @@ class ThemeCommands extends Tasks
             }
         }
         return $result;
-    }
-
-    /**
-     * Get theme build configuration with fallback.
-     *
-     * Retrieves theme_build configuration for a specified site. If the theme_build config is not
-     * present for the specified site, fall back to theme_build for 'default' if that is present.
-     *
-     * @return array
-     *   The theme_build configuration array.
-     */
-    protected function themeBuildConfiguration($siteName = 'default'): array
-    {
-        $siteConfig = $this->getSiteConfig($siteName);
-        $themeBuildConfiguration = $siteConfig['theme_build'] ?? null;
-        // @todo: Re-evaluate this fallback code. It's gross. All it does is reduce duplication
-        // in the sites config file. Is that worth this complexity?
-        if (empty($themeBuildConfiguration)) {
-            $defautConfig = $this->getSiteConfig('default');
-            $themeBuildConfiguration = $defautConfig['theme_build'] ?? null;
-            if (empty($themeBuildConfiguration)) {
-                throw new TaskException($this, "Expected theme configuration not present for $siteName.");
-            }
-            foreach($themeBuildConfiguration as $key => $steps) {
-                $placeholder = Robo::config()->get('sitename_placeholder');
-                if (strpos($steps['theme_path'], $placeholder) !== false) {
-                    $themeBuildConfiguration[$key]['theme_path'] = str_replace($placeholder, $siteName, $themeBuildConfiguration[$key]['theme_path']);
-                }
-            }
-            $this->say("Custom theme_build configuration not present for $siteName.
-            Falling back to configuration found in 'default'.");
-        }
-        return $themeBuildConfiguration;
     }
 }

--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -2,6 +2,7 @@
 
 namespace ChqRobo\Robo\Plugin\Commands;
 
+use ChqRobo\Robo\Plugin\Traits\SitesConfigTrait;
 use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Robo;
@@ -12,6 +13,8 @@ use Robo\Tasks;
  */
 class ThemeCommands extends Tasks
 {
+    use SitesConfigTrait;
+
     /**
      * RoboFile constructor.
      */
@@ -25,15 +28,16 @@ class ThemeCommands extends Tasks
      * Build one or more themes.
      *
      * Configure theme build command(s) to be run using the 'theme_build' key
-     * in your robo.yml file.
+     * in your .sites.config.yml file.
      *
      * @return \Robo\Result
      *   The result of the set of tasks.
      */
-    public function themeBuild(): Result
+    public function themeBuild($siteName = 'default'): Result
     {
-        if (empty($themeBuildConfiguration = Robo::config()->get('theme_build'))) {
-            throw new TaskException($this, 'Expected theme configuration not present: theme_build');
+        $sitesConfig = $this->getSiteConfig($siteName);
+        if (empty($themeBuildConfiguration = $sitesConfig['theme_build'])) {
+            throw new TaskException($this, "Expected theme configuration not present for $siteName.");
         }
         $this->io()->title("building themes");
         foreach ($themeBuildConfiguration as $themeConfig) {

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -2,8 +2,8 @@
 
 namespace ChqRobo\Robo\Plugin\Traits;
 
-use Drupal\Component\Serialization\Yaml;
 use Robo\Exception\TaskException;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Trait to provide site configuration functionality to Robo commands.
@@ -24,7 +24,7 @@ trait SitesConfigTrait
         if (!file_exists($this->sitesConfigFile)) {
             throw new TaskException($this, "$this->sitesConfigFile not found.");
         }
-        return Yaml::decode(file_get_contents($this->sitesConfigFile));
+        return Yaml::parseFile($this->sitesConfigFile);
     }
 
     /**
@@ -71,6 +71,6 @@ trait SitesConfigTrait
     public function writeSiteConfig(array $sitesConfig)
     {
         ksort($sitesConfig);
-        file_put_contents($this->sitesConfigFile, Yaml::encode($sitesConfig));
+        file_put_contents($this->sitesConfigFile, Yaml::dump($sitesConfig));
     }
 }

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace ChqRobo\Robo\Plugin\Traits;
+
+use Drupal\Component\Serialization\Yaml;
+use Robo\Exception\TaskException;
+
+/**
+ * Trait to provide site configuration functionality to Robo commands.
+ */
+trait SitesConfigTrait
+{
+
+    protected $sitesConfigFile = '.sites.config.yml';
+
+    /**
+     * Load configuration for all sites.
+     *
+     * @return array
+     *   A configuration array for all sites.
+     */
+    protected function getAllSitesConfig(): array
+    {
+        if (!file_exists($this->sitesConfigFile)) {
+            throw new TaskException($this, "$this->sitesConfigFile not found.");
+        }
+        return Yaml::decode(file_get_contents($this->sitesConfigFile));
+    }
+
+    /**
+     * Load sites configuration.
+     *
+     * @param string $siteName
+     *   The site name.
+     *
+     * @return array
+     *   The specified site configuration array.
+     */
+    protected function getSiteConfig($siteName = 'default'): array
+    {
+        $allSitesConfig = $this->getAllSitesConfig();
+        if (empty($allSitesConfig[$siteName])) {
+            throw new TaskException($this, "Configuration for '$siteName' not found.");
+        }
+        return $allSitesConfig[$siteName];
+    }
+
+    /**
+     * Get site configuration value.
+     *
+     * @param string $key
+     *   The site configuration key to load.
+     * @param string $siteName
+     *   The site name.
+     *
+     * @return mixed
+     *   A configuration value.
+     */
+    public function getConfig($key, $siteName = 'default')
+    {
+        $siteConfig = $this->getSiteConfig($siteName);
+        if (empty($siteConfig[$key])) {
+            throw new TaskException($this, "Key $key not found for '$siteName'.");
+        }
+        return $siteConfig[$key];
+    }
+
+    /**
+     * Write site config file.
+     */
+    public function writeSiteConfig(array $sitesConfig)
+    {
+        ksort($sitesConfig);
+        file_put_contents($this->sitesConfigFile, Yaml::encode($sitesConfig));
+    }
+}

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -28,6 +28,28 @@ trait SitesConfigTrait
     }
 
     /**
+     * Get all site names from configuration.
+     *
+     * @return array
+     *   An array of all site names.
+     */
+    public function getAllSiteNames(): array
+    {
+        return array_keys($this->getAllSitesConfig());
+    }
+
+    /**
+     * Determine how many sites are included in sites config.
+     *
+     * @return int
+     *   The number of sites.
+     */
+    public function getSitesCount(): int
+    {
+        return count($this->getAllSitesConfig());
+    }
+
+    /**
      * Load sites configuration.
      *
      * @param string $siteName
@@ -40,7 +62,7 @@ trait SitesConfigTrait
     {
         $allSitesConfig = $this->getAllSitesConfig();
         if (empty($allSitesConfig[$siteName])) {
-            throw new TaskException($this, "Configuration for '$siteName' not found.");
+            throw new TaskException($this, "Configuration for '$siteName' not found in $this->sitesConfigFile.");
         }
         return $allSitesConfig[$siteName];
     }
@@ -60,7 +82,7 @@ trait SitesConfigTrait
     {
         $siteConfig = $this->getSiteConfig($siteName);
         if (empty($siteConfig[$key])) {
-            throw new TaskException($this, "Key $key not found for '$siteName'.");
+            throw new TaskException($this, "Key $key not found for '$siteName' in $this->sitesConfigFile.");
         }
         return $siteConfig[$key];
     }

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -19,7 +19,7 @@ trait SitesConfigTrait
      * @return array
      *   A configuration array for all sites.
      */
-    protected function getAllSitesConfig(): array
+    public function getAllSitesConfig(): array
     {
         if (!file_exists($this->sitesConfigFile)) {
             throw new TaskException($this, "$this->sitesConfigFile not found.");
@@ -88,9 +88,9 @@ trait SitesConfigTrait
     }
 
     /**
-     * Write site config file.
+     * Write sites configuration file.
      */
-    public function writeSiteConfig(array $sitesConfig)
+    public function writeSitesConfig(array $sitesConfig)
     {
         ksort($sitesConfig);
         file_put_contents($this->sitesConfigFile, Yaml::dump($sitesConfig));


### PR DESCRIPTION
## Description
* Added robo commands including `composer robo dev:refresh`:
    > Completely refreshes a development environment including running 'composer install', starting Lando, downloading a database dump, importing it, running 'drush deploy', disabling front-end caches, and providing a login link.
* Moved database:download functionality to this repo. Replaced an AWS CLI implementation with an AWS PHP library.

## Motivation / Context
Provide a better getting started experience for developers.

## Testing Instructions / How This Has Been Tested
Test with PR's that reference this PR (see PR activity below)

## Screenshots
Included in associated PRs.

## Documentation
Yes.