### PR TITLE
Added support for s3 key prefix filtering.

### DIFF
--- a/.sites.config.example.yml
+++ b/.sites.config.example.yml
@@ -1,6 +1,7 @@
 ---
 default:
   database_s3_bucket: S3_BUCKET_NAME
+  database_s3_key_prefix_string: prod-db-prefix
   theme_build:
     - theme_path: web/themes/custom/theme1
       theme_build_commands:

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -178,7 +178,7 @@ class DevelopmentModeCommands extends Tasks
             $s3KeyPrefix = $this->getConfig('database_s3_key_prefix_string', $siteName);
             $this->say("'$siteName' S3 Key prefix: '$s3KeyPrefix'");
             $s3ConfigArray['Prefix'] = $s3KeyPrefix;
-        } catch (SitesConfigException $e) {
+        } catch (TaskException $e) {
             $this->say("No S3 Key prefix found for $siteName.");
         }
         return $s3ConfigArray;


### PR DESCRIPTION
## Description
Added support for s3 key prefix filtering.

## Motivation / Context
Some legacy sites backup multiple databases to one bucket.

## Testing Instructions / How This Has Been Tested
Tested locally. See @markdorison for details.

## Screenshots
N/A

## Documentation
N/A