### PR TITLE
Widen robo/drush version support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "consolidation/robo": "^2",
+        "consolidation/robo": "^1.4 || ^2",
         "squizlabs/php_codesniffer": "^3.5",
         "phpstan/phpstan": "^0.12.77",
         "phpstan/phpstan-deprecation-rules": "^0.12.6",
         "async-aws/s3": "^1.8",
         "php": ">=7.4",
-        "drush/drush": ">=8.0",
+        "drush/drush": "^8 || ^10",
         "webflo/drupal-finder": "^1.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
         "squizlabs/php_codesniffer": "^3.5",
         "phpstan/phpstan": "^0.12.77",
         "phpstan/phpstan-deprecation-rules": "^0.12.6",
-        "drush/drush": "^10.4",
         "async-aws/s3": "^1.8",
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "drush/drush": ">=8.0",
+        "webflo/drupal-finder": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -5,6 +5,7 @@ namespace ChqRobo\Robo\Plugin\Commands;
 use ChqRobo\Robo\Plugin\Traits\SitesConfigTrait;
 use AsyncAws\S3\S3Client;
 use DrupalFinder\DrupalFinder;
+use Drush\Commands\core\DeployCommands;
 use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Robo;
@@ -306,6 +307,12 @@ class DevelopmentModeCommands extends Tasks
     protected function drushDeployLando($siteDir = 'default'): Result
     {
         $this->io()->section('drush deploy.');
+        if (!class_exists('DeployCommands')) {
+            throw new TaskException(
+                $this,
+                "'drush deploy' command not found. Further work is neccesary to support this version of Drush."
+            );
+        }
         return $this->taskExecStack()
             ->dir("web/sites/$siteDir")
             ->exec("lando drush deploy --yes")


### PR DESCRIPTION
## Description
Widen drush version support.

## Motivation / Context
Allow this version chq-robo to be installed on older sites where robo 1.x is needed for Drush. This will also allow the latest version of Drush ^8.4 to be installed. When we installed robo 2.x on D7 sites it caused Drush to downgrade to 8.0.4 (I think) because later versions [require a symfony version](https://github.com/drush-ops/drush/commit/cc75da0ff593777b994abfad6ca8ef0407e61374) that conflicts with robo 2.x.

The biggest blocker to this has since been replaced in the code so there should not be a technical limitation in this project's code 🤞. It would be nice to not have to support robo 1.x, but the functionality on D7 sites is too valuable.

Not _all_ chq-robo functionality will work as expected.

## Testing Instructions / How This Has Been Tested
Tested with private D7 project. (If you have access you will see the reference in the activity log below).
