### PR TITLE
Added catch to handle no db configured for download.

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -336,7 +336,13 @@ class DevelopmentModeCommands extends Tasks
     {
         $this->io()->title('refresh tugboat databases.');
         foreach ($this->getAllSitesConfig() as $siteName => $siteInfo) {
-            $dbPath = $this->databaseDownload($siteName);
+            try {
+                $dbPath = $this->databaseDownload($siteName);
+            } catch (TaskException $e) {
+                $this->yell("$siteName: No database configured. Download/import skipped.");
+                // @todo: Should we run a site-install by default?
+                continue;
+            }
             if (empty($dbPath)) {
                 $this->yell("'$siteName' database path not found.");
                 continue;

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -81,7 +81,7 @@ trait SitesConfigTrait
     public function getConfig($key, $siteName = 'default')
     {
         $siteConfig = $this->getSiteConfig($siteName);
-        if (empty($siteConfig[$key])) {
+        if (!isset($siteConfig[$key])) {
             throw new TaskException($this, "Key $key not found for '$siteName' in $this->sitesConfigFile.");
         }
         return $siteConfig[$key];


### PR DESCRIPTION
## Description
Added catch to handle no db configured for download.

## Motivation / Context
If a site does not have a db bucket configured, it should not fail the entire Tugboat refresh.

## Testing Instructions / How This Has Been Tested
Tested locally.
