### PR TITLE
Adds support for disabling the AdvAgg module.

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -462,7 +462,7 @@ class DevelopmentModeCommands extends Tasks
             ->append(true)
             ->line('')
             ->line('/**')
-            ->line(' *  Disable advagg module.')
+            ->line(' *  If advagg module is present, disable its functionality.')
             ->line(' */')
             ->line('$config[\'advagg.settings\'][\'enabled\'] = FALSE;')
             ->run();

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -462,7 +462,7 @@ class DevelopmentModeCommands extends Tasks
             ->line('/**')
             ->line(' *  Disable advagg module.')
             ->line('*/')
-            ->line(date('$config[\'advagg.settings\'][\'enabled\'] = FALSE;')
+            ->line('$config[\'advagg.settings\'][\'enabled\'] = FALSE;')
             ->run();
         return $result;
     }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -459,6 +459,7 @@ class DevelopmentModeCommands extends Tasks
             ->from('# $settings[\'cache\'][\'bins\'][\'page\'] = ')
             ->to('$settings[\'cache\'][\'bins\'][\'page\'] = ')
             ->taskWriteToFile($devSettingsPath)
+            ->append(TRUE)
             ->line('/**')
             ->line(' *  Disable advagg module.')
             ->line('*/')

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -460,6 +460,7 @@ class DevelopmentModeCommands extends Tasks
             ->to('$settings[\'cache\'][\'bins\'][\'page\'] = ')
             ->taskWriteToFile($devSettingsPath)
             ->append(TRUE)
+            ->line('')
             ->line('/**')
             ->line(' *  Disable advagg module.')
             ->line('*/')

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -459,7 +459,7 @@ class DevelopmentModeCommands extends Tasks
             ->from('# $settings[\'cache\'][\'bins\'][\'page\'] = ')
             ->to('$settings[\'cache\'][\'bins\'][\'page\'] = ')
             ->taskWriteToFile($devSettingsPath)
-            ->append(TRUE)
+            ->append(true)
             ->line('')
             ->line('/**')
             ->line(' *  Disable advagg module.')

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -458,6 +458,11 @@ class DevelopmentModeCommands extends Tasks
             ->taskReplaceInFile($devSettingsPath)
             ->from('# $settings[\'cache\'][\'bins\'][\'page\'] = ')
             ->to('$settings[\'cache\'][\'bins\'][\'page\'] = ')
+            ->taskWriteToFile($devSettingsPath)
+            ->line('/**')
+            ->line(' *  Disable advagg module.')
+            ->line('*/')
+            ->line(date('$config[\'advagg.settings\'][\'enabled\'] = FALSE;')
             ->run();
         return $result;
     }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -463,7 +463,7 @@ class DevelopmentModeCommands extends Tasks
             ->line('')
             ->line('/**')
             ->line(' *  Disable advagg module.')
-            ->line('*/')
+            ->line(' */')
             ->line('$config[\'advagg.settings\'][\'enabled\'] = FALSE;')
             ->run();
         return $result;


### PR DESCRIPTION
## Description
I discovered that on CHQ running of the `composer robo frontend:dev-enable` command did not disable the advanced aggregation module, which means the intended outcome for front-end devs is never reached.

## Motivation / Context
Some sites use the [AdvAgg](https://www.drupal.org/project/advagg) module and thus will need to have it also disabled whenever the `composer robo frontend:dev-enable` command is run.

## Testing Instructions / How This Has Been Tested
Pointed a local Drupal site to this branch and tested `composer robo frontend:dev-enable` and `composer robo:dev-refrsh`. Now the follow snippet is added to the bottom of the resulting `settings.local.php` file:

```php
/**
 *  Disable advagg module.
 */
$config['advagg.settings']['enabled'] = FALSE;
```

## Questions
* Is there a better way to handle this? 
* Will sites that don't use AdvAgg simply ignore this config override? I think the answer is yes.