### PR TITLE
Allow customization of drupal_document_root with fallback.

### DIFF
--- a/robo.yml
+++ b/robo.yml
@@ -11,3 +11,4 @@ phpcs_ignore_paths:
   - '*/themes/*/libraries/'
 phpcs_standards:
   - PSR12
+drupal_document_root: web

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -275,6 +275,7 @@ class DevelopmentModeCommands extends Tasks
     public function drupalLoginLink($siteDir = 'default', $lando = true): Result
     {
         $this->io()->section("create login link.");
+        $docRootDir = Robo::config()->get('drupal_document_root') ?? 'web';
         if ($lando) {
             $uri = $this->landoUri($siteDir);
             $this->say("Lando URI detected: $uri");
@@ -282,12 +283,12 @@ class DevelopmentModeCommands extends Tasks
                 ->arg('drush')
                 ->arg('user:login')
                 ->option('--uri', $uri)
-                ->dir("web/sites/$siteDir")
+                ->dir("$docRootDir/sites/$siteDir")
                 ->run();
         }
         return $this->taskExec('../../../drush')
             ->arg('user:login')
-            ->dir("web/sites/$siteDir")
+            ->dir("$docRootDir/sites/$siteDir")
             ->run();
     }
 
@@ -388,8 +389,9 @@ class DevelopmentModeCommands extends Tasks
                 "'drush deploy' command not found. Further work is neccesary to support this version of Drush."
             );
         }
+        $docRootDir = Robo::config()->get('drupal_document_root') ?? 'web';
         return $this->taskExecStack()
-            ->dir("web/sites/$siteDir")
+            ->dir("$docRootDir/sites/$siteDir")
             ->exec("lando drush deploy --yes")
             // Import the latest configuration again. This includes the latest
             // configuration_split configuration. Importing this twice ensures that


### PR DESCRIPTION
## Description
Allow customization of drupal_document_root with fallback.

## Motivation / Context
Not all sites use `web/` as their document root.

## Testing Instructions / How This Has Been Tested
Tested locally.

## Documentation
Updated robo.yml example.