### PR TITLE
Fix multi-site URI check.

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -314,8 +314,10 @@ class DevelopmentModeCommands extends Tasks
                 );
             }
             // Detect multi-site configurations.
+            // We look for the $siteDir to be at the beginning of the appserver
+            // proxy URL.
             $siteDomains = array_filter($landoCfg['proxy']['appserver'], fn($domain) =>
-                strpos($domain, $siteDir) !== false);
+                strpos($domain, $siteDir) == 0);
             if (count($siteDomains) > 1) {
                 $this->say('More than one possible URI found in Lando config >>> ' . implode(' | ', $siteDomains));
             } elseif (count($siteDomains) == 1) {

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -317,7 +317,7 @@ class DevelopmentModeCommands extends Tasks
             // We look for the $siteDir to be at the beginning of the appserver
             // proxy URL.
             $siteDomains = array_filter($landoCfg['proxy']['appserver'], fn($domain) =>
-                strpos($domain, $siteDir) == 0);
+                strpos($domain, $siteDir) === 0);
             if (count($siteDomains) > 1) {
                 $this->say('More than one possible URI found in Lando config >>> ' . implode(' | ', $siteDomains));
             } elseif (count($siteDomains) == 1) {


### PR DESCRIPTION
## Description
Fix multi-site URI check.

## Motivation / Context
Failing when multiple of the URIs contain, but do not start with the $siteDir.

## Testing Instructions / How This Has Been Tested
Tested locally.

## Documentation
N/A