### PR TITLE
Add Twig linting.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,3 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[composer.{json,lock}]
-indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.{json,lock}]
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "async-aws/s3": "^1.8",
         "php": ">=7.4",
         "drush/drush": "^8 || ^10",
-        "webflo/drupal-finder": "^1.2"
+        "webflo/drupal-finder": "^1.2",
+        "vincentlanglet/twig-cs-fixer": "^0.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/robo.drupal.example.yml
+++ b/robo.drupal.example.yml
@@ -25,3 +25,4 @@ phpcs_ignore_paths:
 phpcs_standards:
   - Drupal
   - DrupalPractice
+twig_lint_enable: true

--- a/robo.yml
+++ b/robo.yml
@@ -12,3 +12,4 @@ phpcs_ignore_paths:
 phpcs_standards:
   - PSR12
 drupal_document_root: web
+twig_lint_enable: false

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -99,13 +99,15 @@ class CICommands extends Tasks
         $standards = implode(',', $this->getCodingStandards());
         $extensions = implode(',', $this->phpcsCheckExtensions);
         $ignorePaths = implode(',', $this->phpcsIgnorePaths);
-        return $this->taskExecStack()
-            ->stopOnFail()
-            ->exec('vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer')
-            ->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
-                --ignore=$ignorePaths $this->customCodePaths")
-            ->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths")
-            ->run();
+        /** @var \Robo\Task\CommandStack $stack */
+        $stack = $this->taskExecStack()->stopOnFail();
+        $stack->exec('vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer');
+        $stack->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
+                --ignore=$ignorePaths $this->customCodePaths");
+        if ($this->lintTwigFiles) {
+            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths");
+        }
+        return $stack->run();
     }
 
     /**

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -35,7 +35,7 @@ class CICommands extends Tasks
     protected $customCodePaths;
 
     /**
-     * Boolean indicating if Twig files should be linted.
+     * Boolean indicating whether Twig files should be linted.
      *
      * @var bool
      */
@@ -103,7 +103,7 @@ class CICommands extends Tasks
         $stack = $this->taskExecStack()->stopOnFail();
         $stack->exec('vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer');
         $stack->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
-                --ignore=$ignorePaths $this->customCodePaths");
+            --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
             $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths");
         }
@@ -127,7 +127,7 @@ class CICommands extends Tasks
         $stack = $this->taskExecStack()->stopOnFail();
         $stack->exec('vendor/bin/phpcbf --config-set installed_paths vendor/drupal/coder/coder_sniffer');
         $stack->exec("vendor/bin/phpcbf --standard=$standards --extensions=$extensions \
-                    --ignore=$ignorePaths $this->customCodePaths");
+                --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
             $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --fix");
         }

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -96,6 +96,7 @@ class CICommands extends Tasks
             ->exec('vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer')
             ->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
                 --ignore=$ignorePaths $this->customCodePaths")
+            ->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths")
             ->run();
     }
 
@@ -117,6 +118,7 @@ class CICommands extends Tasks
             ->exec('vendor/bin/phpcbf --config-set installed_paths vendor/drupal/coder/coder_sniffer')
             ->exec("vendor/bin/phpcbf --standard=$standards --extensions=$extensions \
                 --ignore=$ignorePaths $this->customCodePaths")
+          ->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --fix")
             ->run();
     }
 

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -89,7 +89,7 @@ class CICommands extends Tasks
     /**
      * Command to check coding standards.
      *
-     * @aliases phpcs
+     * @aliases phpcs twigcs
      *
      * @return \Robo\Result
      *   The result of the set of tasks.


### PR DESCRIPTION
## Description
- Adds Twig code style checks to the code style step.
- Adds automated Twig code style fixing to automated fixing step.

## Motivation / Context
- We want to ensure standardized Twig template formatting.
- https://github.com/ChromaticHQ/chromatichq.com/issues/3314

## Testing Instructions / How This Has Been Tested
Run `composer cs-check` or `composer cs-fix` in a repo that is using this branch.

## Screenshots
<img width="1043" alt="127340685-86ffa043-1e74-40d7-a035-17a148ad0ddd" src="https://user-images.githubusercontent.com/1349906/127872348-597514d1-53f0-46b4-9e36-db545be9238a.png">


## Documentation
Added example to template file.
