### PR TITLE
Adds setup:codespaces command

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -516,7 +516,7 @@ class DevelopmentModeCommands extends Tasks
     {
         $this->io()->title('Symlinking file system.');
         $docRootDir = Robo::config()->get('drupal_document_root') ?? 'web';
-        $codespaces_directory = getenv('PWD') . '/' .$docRootDir;
+        $codespaces_directory = getenv('PWD') . '/' . $docRootDir;
         if (empty($codespaces_directory)) {
             throw new TaskException($this, 'Codespaces directory is unavailable.');
         }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -514,7 +514,7 @@ class DevelopmentModeCommands extends Tasks
      */
     public function setupCodespaces()
     {
-        $codespaces_directory = getenv('OLDPWD');
+        $codespaces_directory = getenv('PWD') . '/web';
         if (empty($codespaces_directory)) {
             throw new TaskException($this, 'Codespaces directory is unavailable.');
         }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -544,7 +544,16 @@ class DevelopmentModeCommands extends Tasks
         $result = $this->taskExec('composer robo theme:build')->run();
 
         $this->io()->section('Drush deploy.');
-        $result = $this->taskExec('vendor/bin/drush deploy --yes')->run();
+        $result = $this->taskExecStack()
+            ->exec("vendor/bin/drush deploy --yes")
+            // Import the latest configuration again. This includes the latest
+            // configuration_split configuration. Importing this twice ensures that
+            // the latter command enables and disables modules based upon the most up
+            // to date configuration. Additional information and discussion can be
+            // found here:
+            // https://github.com/drush-ops/drush/issues/2449#issuecomment-708655673
+            ->exec("drush config:import --yes")
+            ->run();
         return $result;
     }
 }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -543,8 +543,8 @@ class DevelopmentModeCommands extends Tasks
         $this->io()->section('Building theme.');
         $result = $this->taskExec('composer robo theme:build')->run();
 
-        $this->io()->section('Clearing Drupal cache.');
-        $result = $this->taskExec('vendor/bin/drush cr')->run();
+        $this->io()->section('Drush deploy.');
+        $result = $this->taskExec('vendor/bin/drush deploy --yes')->run();
         return $result;
     }
 }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -541,9 +541,6 @@ class DevelopmentModeCommands extends Tasks
 
         $this->io()->section('Clearing Drupal cache.');
         $result = $this->taskExec('vendor/bin/drush cr')->run();
-
-        $this->io()->section('Starting front-end development.');
-        $result = $this->taskExec('yarn --cwd web/themes/chromatic/ start')->run();
         return $result;
     }
 }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -514,11 +514,13 @@ class DevelopmentModeCommands extends Tasks
      */
     public function setupCodespaces()
     {
-        $codespaces_directory = getenv('PWD') . '/web';
+        $this->io()->title('Symlinking file system.');
+        $docRootDir = Robo::config()->get('drupal_document_root') ?? 'web';
+        $codespaces_directory = getenv('PWD') . '/' .$docRootDir;
         if (empty($codespaces_directory)) {
             throw new TaskException($this, 'Codespaces directory is unavailable.');
         }
-        $result = $this->taskExec('rm /var/www/html')->run();
+        $this->taskDeleteDir('/var/www/html')->run();
         $result = $this->taskExec("ln -s $codespaces_directory /var/www/html")->run();
 
         $this->io()->title('Start apache, forwarding port 80.');

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -510,9 +510,13 @@ class DevelopmentModeCommands extends Tasks
     /**
      * Setup a site in GitHub Codespaces.
      *
+     * @return \Robo\Result
+     *   The result of the set of tasks.
+     *
      * @throws \Robo\Exception\TaskException
+     *
      */
-    public function setupCodespaces()
+    public function setupCodespaces(): Result
     {
         $this->io()->title('Symlinking file system.');
         $docRootDir = Robo::config()->get('drupal_document_root') ?? 'web';

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -541,6 +541,9 @@ class DevelopmentModeCommands extends Tasks
 
         $this->io()->section('Clearing Drupal cache.');
         $result = $this->taskExec('vendor/bin/drush cr')->run();
+
+        $this->io()->section('Starting front-end development.');
+        $result = $this->taskExec('yarn --cwd web/themes/chromatic/ start')->run();
         return $result;
     }
 }


### PR DESCRIPTION
## Description
Adds a `setup:codespaces` command that does the following:

1. Symlink `/var/www/html` to the `/web` directory on a site.
2. Start apache and forward port 80.
3. Download the database.
4. Import the database.
5. Build the theme.
6. Clear the cache.

## Motivation / Context
https://github.com/ChromaticHQ/chromatichq.com/pull/3472/ has issues when executing other robo commands from another robofile, returning a `$result` object instead of a string that we need for our database imports.

## Testing Instructions / How This Has Been Tested
Testing in the https://github.com/ChromaticHQ/chromatichq.com/pull/3472/ codespace.

## Screenshots
TBD

## Documentation
TBD
