### PR TITLE
Exclude node_modules from Twig linting.

### DIFF
--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -1,0 +1,9 @@
+<?php
+
+$finder = new TwigCsFixer\File\Finder();
+$finder->exclude('node_modules');
+
+$config = new TwigCsFixer\Config\Config();
+$config->setFinder($finder);
+
+return $config;

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -105,7 +105,8 @@ class CICommands extends Tasks
         $stack->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
             --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
-            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --config=vendor/chromatichq/chq-robo/.twig-cs-fixer.php");
+            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths
+                --config=vendor/chromatichq/chq-robo/.twig-cs-fixer.php");
         }
         return $stack->run();
     }
@@ -129,7 +130,9 @@ class CICommands extends Tasks
         $stack->exec("vendor/bin/phpcbf --standard=$standards --extensions=$extensions \
                 --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
-            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --fix --config=vendor/chromatichq/chq-robo/.twig-cs-fixer.php");
+            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths
+                --fix
+                --config=vendor/chromatichq/chq-robo/.twig-cs-fixer.php");
         }
 
         return $stack->run();

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -105,7 +105,7 @@ class CICommands extends Tasks
         $stack->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
             --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
-            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths");
+            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --config=vendor/chromatichq/chq-robo/.twig-cs-fixer.php");
         }
         return $stack->run();
     }
@@ -129,7 +129,7 @@ class CICommands extends Tasks
         $stack->exec("vendor/bin/phpcbf --standard=$standards --extensions=$extensions \
                 --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
-            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --fix");
+            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths --fix --config=vendor/chromatichq/chq-robo/.twig-cs-fixer.php");
         }
 
         return $stack->run();


### PR DESCRIPTION
## Description

Exclude node_modules from Twig linting.

## Motivation / Context

Once theme dependencies are built locally, the `composer cs-check` command will often fail when it finds malformed Twig templates in external dependencies. This will exclude those directories from Twig linting.

👀 I proposed adding this to the default finder in the Twig linting repo. If my idea is accepted there, this PR should be closed.

- https://github.com/VincentLanglet/Twig-CS-Fixer/issues/40

## Testing Instructions / How This Has Been Tested

Required this branch into a repo that previously had this issue, then ran `composer cs-check` and saw it pass with no issues.

## Screenshots

<img width="534" alt="Screen Shot 2021-10-04 at 4 18 19 PM" src="https://user-images.githubusercontent.com/1349906/135926161-6ab7702b-4150-4720-900e-b99e8b402fa6.png">

## Documentation
Maybe?
