### PR TITLE
Widen Robo support now that Drush supports Robo 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "consolidation/robo": "^1.4 || ^2",
+        "consolidation/robo": "^1.4 || ^2 || ^3",
         "squizlabs/php_codesniffer": "^3.5",
         "phpstan/phpstan": "^0.12.77",
         "phpstan/phpstan-deprecation-rules": "^0.12.6",


### PR DESCRIPTION

## Description
Widen Robo support now that Drush supports Robo 3.x.

## Motivation / Context
https://github.com/drush-ops/drush/commit/3d91cf932

## Testing Instructions / How This Has Been Tested
Tests should pass.
