### PR TITLE
Update Twig linter to add node_module exclusion.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=7.4",
         "drush/drush": "^8 || ^10",
         "webflo/drupal-finder": "^1.2",
-        "vincentlanglet/twig-cs-fixer": "^0.4.0"
+        "vincentlanglet/twig-cs-fixer": "^0.4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description
Replaces https://github.com/ChromaticHQ/chq-robo/pull/36.

## Motivation / Context
Exclude the `node_modules` directory from Twig linting.

## Testing Instructions / How This Has Been Tested
`composer cs-check` should pass when running in a repo with the theme built.
