### PR TITLE
Run theme build command with bash in login mode

### DIFF
--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -48,7 +48,7 @@ class ThemeCommands extends Tasks
             $themePath = $themeConfig['theme_path'];
             $this->io()->section("building theme at $themePath");
             foreach ($themeConfig['theme_build_commands'] as $themeBuildCommand) {
-                $result = $this->taskExec($themeBuildCommand)
+                $result = $this->taskExec("bash -lc \"$themeBuildCommand\"")
                     ->dir($themePath)
                     ->run();
             }

--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -48,6 +48,9 @@ class ThemeCommands extends Tasks
             $themePath = $themeConfig['theme_path'];
             $this->io()->section("building theme at $themePath");
             foreach ($themeConfig['theme_build_commands'] as $themeBuildCommand) {
+                // Run theme build commands in a Bash subshell with login mode
+                // enabled to ensure nvm is loaded prior to running any
+                // Node-based commands.
                 $result = $this->taskExec("bash -lc \"$themeBuildCommand\"")
                     ->dir($themePath)
                     ->run();


### PR DESCRIPTION
## Description

This PR updates our theme build command to wrap the command itself in `bash -lc "COMMAND_NAME"`.

## Motivation / Context

With [our move to use `nvm` to install Node, we end up needing to run all Node-based commands within a context that loads nvm first. The simplest way to do this is to run said commands in a Bash shell with login mode enabled.

See chromatichq/chromatichq.com#3169 for details on why this is needed.

## Testing Instructions / How This Has Been Tested

If the CHQ PR linked above builds correctly, this PR should be good to go.

## Screenshots

n/a

## Documentation

I added a code comment above the line in question to clarify why we’re doing this.