### PR TITLE
Revert "Run theme build command with bash in login mode (#43)"

### DIFF
--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -48,10 +48,7 @@ class ThemeCommands extends Tasks
             $themePath = $themeConfig['theme_path'];
             $this->io()->section("building theme at $themePath");
             foreach ($themeConfig['theme_build_commands'] as $themeBuildCommand) {
-                // Run theme build commands in a Bash subshell with login mode
-                // enabled to ensure nvm is loaded prior to running any
-                // Node-based commands.
-                $result = $this->taskExec("bash -lc \"$themeBuildCommand\"")
+                $result = $this->taskExec($themeBuildCommand)
                     ->dir($themePath)
                     ->run();
             }


### PR DESCRIPTION
## Description

This PR reverts commit ee95500bbde2d408244a3a4bbc7ed266c5eb4736 and, with it, our reliance on `bash` to run theme build commands.

## Motivation / Context

We had made this change under the (incorrect) assumption that every environment in which this command is run uses Bash to install nvm (and, therefore, Node.js and Yarn). This assumption was made as part of a greater effort to manage Node.js versions using nvm everywhere. The assumption is incorrect because Platform.sh uses Dash by default. Seeing as any given environment may use a different default, it seems misguided to couple our theme-building operations to a specific shell program.

## Testing Instructions / How This Has Been Tested

This PR strictly reverts the previous commit, so there shouldn’t be a need to demonstrate that it will work in Benz. Once this is merged, I will tag a new version and:
1. Test that the new version causes no theme build errors in `benz-platform`.
2. Submit a PR in CHQ to revert our reliance on `php-apache-nvm`.
3. Submit a PR in `docker-images` to remove the `php-apache-nvm` images.

## Screenshots

n/a

## Documentation

This update also removes a comment in the logic itself explaining why we were using Bash in the first place.