### PR TITLE
Fixed method exposed as command.

### DIFF
--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -90,7 +90,7 @@ trait SitesConfigTrait
     /**
      * Write sites configuration file.
      */
-    public function writeSitesConfig(array $sitesConfig)
+    protected function writeSitesConfig(array $sitesConfig)
     {
         ksort($sitesConfig);
         file_put_contents($this->sitesConfigFile, Yaml::dump($sitesConfig));


### PR DESCRIPTION
## Description
Fixed method exposed as robo command by switching it from from public to protected.


## Motivation / Context
<img width="476" alt="CleanShot 2021-11-08 at 17 30 53@2x" src="https://user-images.githubusercontent.com/20355/140828531-1a62a2bd-12dc-4c06-b39c-0e0992a8a443.png">

## Testing Instructions / How This Has Been Tested
Tested locally. 

1. Method is no longer exposed as a command.
2. Downstream commands that consume this trait and use this method still work as expected.
