### PR TITLE
Remove explicit installed paths for PHPCS.

### DIFF
--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -100,7 +100,6 @@ class CICommands extends Tasks
         $ignorePaths = implode(',', $this->phpcsIgnorePaths);
         /** @var \Robo\Task\CommandStack $stack */
         $stack = $this->taskExecStack()->stopOnFail();
-        $stack->exec('vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer');
         $stack->exec("vendor/bin/phpcs --standard=$standards --extensions=$extensions \
             --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {
@@ -124,7 +123,6 @@ class CICommands extends Tasks
         $ignorePaths = implode(',', $this->phpcsIgnorePaths);
         /** @var \Robo\Task\CommandStack $stack */
         $stack = $this->taskExecStack()->stopOnFail();
-        $stack->exec('vendor/bin/phpcbf --config-set installed_paths vendor/drupal/coder/coder_sniffer');
         $stack->exec("vendor/bin/phpcbf --standard=$standards --extensions=$extensions \
                 --ignore=$ignorePaths $this->customCodePaths");
         if ($this->lintTwigFiles) {


### PR DESCRIPTION
## Description
Remove explicit installed paths for PHPCS.

## Motivation / Context
Testing of `drupal/coder` on downstream repos is failing due to the [inclusion of a new dependency in Coder 8.3.14](https://www.drupal.org/project/coder/issues/3010032). It seems that the explicit setting of installed paths is [no longer needed](https://www.drupal.org/project/coder/issues/3010032#comment-14391003) due to a new `coder` implementation:

> We're currently using dealerdirect/phpcodesniffer-composer-installer to automatically set the installed_paths on Composer install.
> ...
> This issue will also occur when phpcs --config-set installed_paths is executed after the composer install without including the Slevomat standard, as it will overwrite the automatically set installed_paths.

## Testing Instructions / How This Has Been Tested
* Tested locally on CHQ. Verified by adding an incorrect "standard" to our config and PHPCS errored as expected; therefore, PHPCS is detecting the Drupal and DrupalPractice standards as we would expect.
* Tests continued to pass with this change.

