### PR TITLE
Update README to use chromatic/usher

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ downstream repos.
 
 ## Installation
 
-`composer require chromatichq/usher`
+`composer require chromatic/usher`
 
 ## Configuration
 


### PR DESCRIPTION
## Description
The instruction currently reads `composer require chromatichq/usher`, but it should be `composer require chromatic/usher`, without the "hq" in "chromatichq".
