### PR TITLE
composer robo database:download on a Windows machine might crash depending on filename of DB-dump

### DIFF
--- a/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
+++ b/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
@@ -55,20 +55,21 @@ trait DatabaseDownloadTrait
         // Ensure objects are sorted by last modified date.
         usort($objects, fn($a, $b) => $a->getLastModified()->getTimestamp() <=> $b->getLastModified()->getTimestamp());
         $latestDatabaseDump = array_pop($objects);
-        $dbFilename = $this->sanitizeFileNameForWindows($latestDatabaseDump->getKey());
+        $dbFilename = $latestDatabaseDump->getKey();
+        $localFilename = $this->sanitizeFileNameForWindows($dbFilename);
 
-        if (file_exists($dbFilename)) {
-            $this->say("Skipping download. Latest database dump file exists >>> $dbFilename");
+        if (file_exists($localFilename)) {
+            $this->say("Skipping download. Latest database dump file exists >>> $localFilename");
         } else {
             $result = $s3->GetObject([
                 'Bucket' => $this->s3BucketForSite($siteName),
                 'Key' => $dbFilename,
             ]);
-            $fp = fopen($dbFilename, 'wb');
+            $fp = fopen($localFilename, 'wb');
             stream_copy_to_stream($result->getBody()->getContentAsResource(), $fp);
-            $this->say("Database dump file downloaded >>> $dbFilename");
+            $this->say("Database dump file downloaded >>> $localFilename");
         }
-        return $dbFilename;
+        return $localFilename;
     }
 
     /**

--- a/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
+++ b/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
@@ -56,20 +56,20 @@ trait DatabaseDownloadTrait
         usort($objects, fn($a, $b) => $a->getLastModified()->getTimestamp() <=> $b->getLastModified()->getTimestamp());
         $latestDatabaseDump = array_pop($objects);
         $dbFilename = $latestDatabaseDump->getKey();
-        $localFilename = $this->sanitizeFileNameForWindows($dbFilename);
+        $downloadFileName = $this->sanitizeFileNameForWindows($dbFilename);
 
-        if (file_exists($localFilename)) {
-            $this->say("Skipping download. Latest database dump file exists >>> $localFilename");
+        if (file_exists($downloadFileName)) {
+            $this->say("Skipping download. Latest database dump file exists >>> $downloadFileName");
         } else {
             $result = $s3->GetObject([
                 'Bucket' => $this->s3BucketForSite($siteName),
                 'Key' => $dbFilename,
             ]);
-            $fp = fopen($localFilename, 'wb');
+            $fp = fopen($downloadFileName, 'wb');
             stream_copy_to_stream($result->getBody()->getContentAsResource(), $fp);
-            $this->say("Database dump file downloaded >>> $localFilename");
+            $this->say("Database dump file downloaded >>> $downloadFileName");
         }
-        return $localFilename;
+        return $downloadFileName;
     }
 
     /**


### PR DESCRIPTION
Sanitize filename for Windows.

Currently the filename that's used for downloading a DB-Dump from AWS S3 can contain characters that are Windows unfriendly, like a colon(`:`).

If something likes that occurs doing a `composer robo database:download` on a Windows machine _might_ start The Apocalypse, but at the very least crashes with:

```
ERROR: stream_copy_to_stream() expects parameter 2 to be resource, bool given
in \path\to\vendor\chromatic\usher\src\Robo\Plugin\Traits\DatabaseDownloadTrait.php:68

PHP Warning:  stream_copy_to_stream() expects parameter 2 to be resource, bool given in \path\to\vendor\chromatic\usher\src\Robo\Plugin\Traits\DatabaseDownloadTrait.php on line 68
PHP Stack trace:
PHP   1. {main}() \path\to\vendor\bin\robo:0
PHP   2. include() \path\to\vendor\bin\robo:112
PHP   3. Robo\Runner->execute() \path\to\vendor\consolidation\robo\robo:48
PHP   4. Robo\Runner->run() \path\to\vendor\consolidation\robo\src\Runner.php:158
PHP   5. Robo\Application->run() \path\to\vendor\consolidation\robo\src\Runner.php:282
PHP   6. Robo\Application->doRun() \path\to\vendor\symfony\console\Application.php:149
PHP   7. Robo\Application->doRunCommand() \path\to\vendor\symfony\console\Application.php:273
PHP   8. Consolidation\AnnotatedCommand\AnnotatedCommand->run() \path\to\vendor\symfony\console\Application.php:1027
PHP   9. Consolidation\AnnotatedCommand\AnnotatedCommand->execute() \path\to\vendor\symfony\console\Command\Command.php:255
PHP  10. Consolidation\AnnotatedCommand\CommandProcessor->process() \path\to\vendor\consolidation\annotated-command\src\AnnotatedCommand.php:350
PHP  11. Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter() \path\to\vendor\consolidation\annotated-command\src\CommandProcessor.php:176
PHP  12. Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback() \path\to\vendor\consolidation\annotated-command\src\CommandProcessor.php:212
PHP  13. call_user_func_array:{\path\to\vendor\consolidation\annotated-command\src\CommandProcessor.php:257}() \path\to\vendor\consolidation\annotated-command\src\CommandProcessor.php:257
PHP  14. Usher\Robo\Plugin\Commands\Drupal7DevelopmentModeCommands->databaseDownload() \path\to\vendor\consolidation\annotated-command\src\CommandProcessor.php:257
PHP  15. stream_copy_to_stream() \path\to\vendor\chromatic\usher\src\Robo\Plugin\Traits\DatabaseDownloadTrait.php:68
```

This PR tries to be inclusive to our Windows-using friends.