### PR TITLE
Fixed call to method with incorrect case.

### DIFF
--- a/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
+++ b/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
@@ -60,7 +60,7 @@ trait DatabaseDownloadTrait
         if (file_exists($dbFilename)) {
             $this->say("Skipping download. Latest database dump file exists >>> $dbFilename");
         } else {
-            $result = $s3->GetObject([
+            $result = $s3->getObject([
                 'Bucket' => $this->s3BucketForSite($siteName),
                 'Key' => $dbFilename,
             ]);


### PR DESCRIPTION
## Description
Fixed call to method with incorrect case.

## Motivation / Context
`Call to method AsyncAws\S3\S3Client::getObject() with incorrect case: GetObject`

## Testing Instructions / How This Has Been Tested
Tests should pass.
