### PR TITLE
`composer robo uli` on a site with one` .lando.yml` and Front-End and Back-End living in seperate sub-directories fix

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -232,8 +232,15 @@ class DevelopmentModeBaseCommands extends Tasks
      */
     protected function landoUri($siteDir): string
     {
-        $landoConfigPath = "$this->drupalRoot/../.lando.yml";
-        $landoCfg = Yaml::parseFile($landoConfigPath);
+        try {
+            $landoCfg = Yaml::parseFile($landoConfigPath);
+        }
+        catch (ParseException $exception) {
+            // This site could have a Front- and Back-end site in different
+            // sub-directories with a the lando.yml in the root directory.
+            $landoConfigPath = "$this->drupalRoot/../../.lando.yml";
+            $landoCfg = Yaml::parseFile($landoConfigPath);
+        }
         // First, check for multisite proxy configuration.
         if (isset($landoCfg['proxy']['appserver'])) {
             if ($siteDir === 'default') {

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -248,7 +248,7 @@ class DevelopmentModeBaseCommands extends Tasks
                 $this->say("Unable to load Lando config from $landoConfigPath.");
             }
             // Break out of the loop if valid configuration was found.
-            if ($landoCfg) {
+            if ($landoCfg === true) {
                 $this->say("Found Lando config at $landoConfigPath.");
                 break;
             }

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -234,8 +234,7 @@ class DevelopmentModeBaseCommands extends Tasks
     {
         try {
             $landoCfg = Yaml::parseFile($landoConfigPath);
-        }
-        catch (ParseException $exception) {
+        } catch (ParseException $exception) {
             // This site could have a Front- and Back-end site in different
             // sub-directories with a the lando.yml in the root directory.
             $landoConfigPath = "$this->drupalRoot/../../.lando.yml";

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -248,10 +248,16 @@ class DevelopmentModeBaseCommands extends Tasks
                 $this->say("Unable to load Lando config from $landoConfigPath.");
             }
             // Break out of the loop if valid configuration was found.
-            if ($landoCfg === true) {
+            if ($landoCfg !== false) {
                 $this->say("Found Lando config at $landoConfigPath.");
                 break;
             }
+        }
+        if ($landoCfg === false) {
+            throw new TaskException(
+                $this,
+                'Unable to determine where the .lando.yml file is located.'
+            );
         }
         // First, check for multisite proxy configuration.
         if (isset($landoCfg['proxy']['appserver'])) {

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -7,6 +7,7 @@ use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Robo;
 use Robo\Tasks;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use Usher\Robo\Plugin\Traits\DatabaseDownloadTrait;
 use Usher\Robo\Plugin\Traits\SitesConfigTrait;
@@ -232,9 +233,11 @@ class DevelopmentModeBaseCommands extends Tasks
      */
     protected function landoUri($siteDir): string
     {
+        $landoConfigPath = "$this->drupalRoot/../.lando.yml";
         try {
             $landoCfg = Yaml::parseFile($landoConfigPath);
-        } catch (ParseException $exception) {
+        }
+        catch (ParseException $exception) {
             // This site could have a Front- and Back-end site in different
             // sub-directories with a the lando.yml in the root directory.
             $landoConfigPath = "$this->drupalRoot/../../.lando.yml";

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -233,11 +233,10 @@ class DevelopmentModeBaseCommands extends Tasks
      */
     protected function landoUri($siteDir): string
     {
-        $landoConfigPath = "$this->drupalRoot/../.lando.yml";
         try {
+            $landoConfigPath = "$this->drupalRoot/../.lando.yml";
             $landoCfg = Yaml::parseFile($landoConfigPath);
-        }
-        catch (ParseException $exception) {
+        } catch (ParseException $exception) {
             // This site could have a Front- and Back-end site in different
             // sub-directories with a the lando.yml in the root directory.
             $landoConfigPath = "$this->drupalRoot/../../.lando.yml";


### PR DESCRIPTION
## Description
The Quick and also Dirty way to solve #69 for Poets.
Please tell me to make this more generic/better.

## Motivation / Context
#69 should have all the motivational and contextual information your heart may desire.

## Testing Instructions / How This Has Been Tested

Result with current Usher release on the Poets Lando:
![image](https://user-images.githubusercontent.com/18569707/162220643-d669da9a-a2be-450e-b833-3a9860a62811.png)

Applied the latest commit on my "UsherLite" clone in Poets.

Result after:
![image](https://user-images.githubusercontent.com/18569707/162726677-538b21c8-4a4c-43eb-a06a-4ba8923f9e46.png)

Also applied the changes to CHQ.com:

Result before:
![image](https://user-images.githubusercontent.com/18569707/162726852-025b5510-f2d6-4a1b-b293-7be6acbe0437.png)

Result after:
![image](https://user-images.githubusercontent.com/18569707/162726999-112b9d46-148a-457f-b716-895362f246d8.png)

**NOTE**
The exception thrown on CHQ.com happens with and without the changes. Opened a new issue for that here: #73 .
The line `>  Found Lando config at D:\htdocs\chromatichq.com/web/../.lando.yml.` in the second screenshot proves that the changes also work for the "default" setup of one directory for Front- and Back-End

