### PR TITLE
Fix regression in `composer robo validate:drupal-config`

### DIFF
--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -50,7 +50,7 @@ class ValidateConfigCommands extends Tasks
             ->run();
         $drushOutput = trim($result->getOutputData());
         $configJson = json_decode($drushOutput);
-        if (!is_null($configJson)) {
+        if (!empty($configJson)) {
             $this->say($drushOutput);
             throw new TaskException(
                 $this,

--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -50,7 +50,9 @@ class ValidateConfigCommands extends Tasks
             ->run();
         $drushOutput = trim($result->getOutputData());
         $configJson = json_decode($drushOutput);
-        if (!empty($configJson)) {
+        // We trimmed $drushOutput, so the OK-output of NULL has become an empty
+        // string.
+        if ($configJson !== '') {
             $this->say($drushOutput);
             throw new TaskException(
                 $this,


### PR DESCRIPTION
## Description
See code change comments and https://devrant.com/rants/764332/tfw-you-learn-that-trim-null-equals-empty-string-in-php-i-m-starting-to-understa

## Motivation / Context
#75 

## Testing Instructions / How This Has Been Tested
Not tested, testing Usher is a bit of a &*^*#@#! TBH. Seems to involve requiring a PR in a real project to show if it works.