### PR TITLE
Fix Config Validation

### DIFF
--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -48,11 +48,8 @@ class ValidateConfigCommands extends Tasks
             ->dir("$this->drupalRoot/sites/$siteDir/")
             ->printOutput(false)
             ->run();
-        $drushOutput = trim($result->getOutputData());
-        $configJson = json_decode($drushOutput);
-        // We trimmed $drushOutput, so the OK-output of NULL has become an empty
-        // string.
-        if ($configJson !== '') {
+        $configDiff = trim($result->getOutputData());
+        if (!is_array($configDiff) || !empty($configDiff)) {
             $this->say($drushOutput);
             throw new TaskException(
                 $this,

--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -48,8 +48,9 @@ class ValidateConfigCommands extends Tasks
             ->dir("$this->drupalRoot/sites/$siteDir/")
             ->printOutput(false)
             ->run();
-        $configDiff = trim($result->getOutputData());
-        if (!is_array($configDiff) || !empty($configDiff)) {
+        $drushOutput = trim($result->getOutputData());
+        $configJson = json_decode($drushOutput);
+        if (!is_array($configJson) || count($configJson) > 0) {
             $this->say($drushOutput);
             throw new TaskException(
                 $this,


### PR DESCRIPTION
## Description
Alters the config validation code to work as expected. I'm not sure what changed, as it was working before. 

This seems to be a regression from https://github.com/ChromaticHQ/usher/pull/76.

## Motivation / Context
Updating Usher on a project caused the config validation to begin failing with no config or code changes.

## Testing Instructions / How This Has Been Tested

This preview works again. 🎉 

- https://dashboard.tugboat.qa/62748037ef17c6f56915a465
