### PR TITLE
Add cache clear after database import.

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -123,6 +123,11 @@ class DevelopmentModeBaseCommands extends Tasks
             $result = $this->taskExec("zcat $dbPath | mysql -h mariadb -u tugboat -ptugboat $dbName")
                 ->run();
             $result = $this->taskExec('rm')->args($dbPath)->run();
+
+            $result = $this->taskExec("$this->vendorDirectory/bin/drush")
+                ->arg('cache:rebuild')
+                ->dir("$this->drupalRoot/sites/$siteName")
+                ->run();
         }
         return $result;
     }


### PR DESCRIPTION
## Description
Runs a cache clear after importing the database.

## Motivation / Context

We are exploring trying to reduce the need to run cache rebuilds on Tugboat previews built from the base preview. Storing a base preview with no cache would aid in that. This is an attempt to do that.

https://github.com/ChromaticHQ/benz-tickets/issues/2803

## Testing Instructions / How This Has Been Tested
TK