### PR TITLE
Add PHP version linting using phpcompatibility/php-compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "webflo/drupal-finder": "^1.2",
         "vincentlanglet/twig-cs-fixer": "^0.4.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-        "phpstan/extension-installer": "^1.1"
+        "phpstan/extension-installer": "^1.1",
+        "phpcompatibility/php-compatibility": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/robo.drupal.example.yml
+++ b/robo.drupal.example.yml
@@ -22,6 +22,7 @@ phpcs_ignore_paths:
   - '*/themes/*/js/'
   - '*/themes/*/node_modules'
   - '*/themes/*/libraries/'
+phpcs_php_version: '8.1'
 phpcs_standards:
   - Drupal
   - DrupalPractice

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -12,6 +12,14 @@ use Robo\Tasks;
  */
 class CICommands extends Tasks
 {
+
+    /**
+     * The default PHP version to lint against.
+     *
+     * @var string
+     */
+    const PHPCS_DEFAULT_PHP_VERSION = '8.0';
+
     /**
      * A comma separated list of the file extensions PHPCS should check.
      *
@@ -41,6 +49,13 @@ class CICommands extends Tasks
     protected $phpcsStandards;
 
     /**
+     * The PHP version to lint against for support.
+     *
+     * @var string
+     */
+    protected $phpcsPhpVersion;
+
+    /**
      * Boolean indicating whether Twig files should be linted.
      *
      * @var bool
@@ -60,6 +75,7 @@ class CICommands extends Tasks
         $this->customCodePaths = implode(' ', $this->getConfigurationValues('custom_code_paths'));
         $this->phpcsStandards = implode(',', $this->getConfigurationValues('phpcs_standards'));
         $this->lintTwigFiles = Robo::config()->get('twig_lint_enable') ?? true;
+        $this->phpcsPhpVersion = Robo::config()->get('phpcs_php_version', $this::PHPCS_DEFAULT_PHP_VERSION);
     }
 
     /**
@@ -133,8 +149,14 @@ class CICommands extends Tasks
         /** @var \Robo\Task\CommandStack $stack */
         $stack = $this->taskExecStack()->stopOnFail();
         $phpBinary = $applyFixes ? 'phpcbf' : 'phpcs';
+        // General PHP linting.
         $stack->exec("vendor/bin/$phpBinary --standard=$this->phpcsStandards --extensions=$this->phpcsCheckExtensions \
                 --ignore=$this->phpcsIgnorePaths $this->customCodePaths");
+        // Check for PHP version compatibility.
+        $stack->exec("vendor/bin/phpcs --standard=PHPCompatibility --severity=1 \
+                --ignore=$this->phpcsIgnorePaths --extensions=php,module,theme \
+                --runtime-set testVersion $this->phpcsPhpVersion- $this->customCodePaths");
+        // Lint Twig files.
         if ($this->lintTwigFiles) {
             $fixFlag = $applyFixes ? '--fix' : '';
             $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths $fixFlag");

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -12,13 +12,12 @@ use Robo\Tasks;
  */
 class CICommands extends Tasks
 {
-
     /**
      * The default PHP version to lint against.
      *
      * @var string
      */
-    const PHPCS_DEFAULT_PHP_VERSION = '8.0';
+    protected const PHPCS_DEFAULT_PHP_VERSION = '8.0';
 
     /**
      * A comma separated list of the file extensions PHPCS should check.


### PR DESCRIPTION
## Description
Adds a standardized to linting for PHP version specific issues.

- https://github.com/PHPCompatibility/PHPCompatibility

⚠️  Should this be a separate command with separate config to allow linting of contrib modules too?

## Motivation / Context
As we update to newer versions of PHP we want to standardize the linting process.

## Testing Instructions / How This Has Been Tested
Run `composer robo cs-check` and confirm there are no issues or only valid issues are flagged.

## Screenshots

<img width="1439" alt="test" src="https://user-images.githubusercontent.com/1349906/194426346-65762c40-6044-43ed-b303-82edc1044b4f.png">


## Documentation
I have added to the example file.
