### PR TITLE
Add D7 compatibility for databaseRefreshTugboat().

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -92,10 +92,13 @@ class DevelopmentModeBaseCommands extends Tasks
     /**
      * Refresh database on Tugboat.
      *
+     * @param bool $drupal7
+     *   TRUE if running against a Drupal 7 site.
+     *
      * @return \Robo\Result
      *   The result of the set of tasks.
      */
-    public function databaseRefreshTugboat(): Result
+    public function databaseRefreshTugboat(bool $drupal7 = false): Result
     {
         $this->io()->title('refresh tugboat databases.');
         $result = null;
@@ -124,10 +127,17 @@ class DevelopmentModeBaseCommands extends Tasks
                 ->run();
             $result = $this->taskExec('rm')->args($dbPath)->run();
 
-            $result = $this->taskExec("$this->vendorDirectory/bin/drush")
-                ->arg('cache:rebuild')
-                ->dir("$this->drupalRoot/sites/$siteName")
-                ->run();
+            if ($drupal7) {
+                $result = $this->taskExec("$this->vendorDirectory/bin/drush")
+                    ->arg('cache:rebuild')
+                    ->dir("$this->drupalRoot/sites/$siteName")
+                    ->run();
+            } else {
+                $result = $this->taskExec("$this->vendorDirectory/bin/drush")
+                    ->arg('cache-clear all')
+                    ->dir("$this->drupalRoot/sites/$siteName")
+                    ->run();
+            }
         }
         return $result;
     }


### PR DESCRIPTION
## Description
Add D7 compatibility for databaseRefreshTugboat().

What do you think of this approach? We could add a separate command, but given its only the [cache clear](https://github.com/ChromaticHQ/usher/commit/4d02216282412f8133de6accee4152c87ffe9b5b) that differs, I opted to wrap it in a conditional.

## Motivation / Context
https://chromatic.slack.com/archives/C02K4QA7V/p1666880292105249?thread_ts=1666796876.984279&cid=C02K4QA7V

## Testing Instructions / How This Has Been Tested
Test against this branch.

