### PR TITLE
Remove deprecated ::set-output command.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get composer cache directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Description
Remove deprecated command.

## Motivation / Context
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://dev.to/cicirello/how-to-patch-the-deprecated-set-output-in-github-workflows-and-in-container-actions-9co

## Testing Instructions / How This Has Been Tested
The GH Action should run without issue.

## Screenshots
![Screenshot 2022-12-06 at 5 06 50 PM](https://user-images.githubusercontent.com/1349906/206044317-f250fc4a-1cc1-4664-94d5-61f164eda74f.png)


## Documentation
N/A
