### PR TITLE
Update CI trigger to point to correct branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   # Trigger the workflow on pushes to the main branch and all pull requests.
   push:
     branches:
-      - main
+      - 2.x
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   # Trigger the workflow on pushes to the main branch and all pull requests.
   push:
     branches:
-      - 2.x
+      - **.x
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   # Trigger the workflow on pushes to the main branch and all pull requests.
   push:
     branches:
-      - **.x
+      - "**.x"
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Description
Update CI trigger to point to correct branch

## Motivation / Context
The CI workflow was running against all PRs as expected but not against the default branch since it has been renamed from `main` -> `2.x`

## Testing Instructions / How This Has Been Tested
Review diff.