### PR TITLE
Removed potentially confusing log message.

### DIFF
--- a/src/Robo/Plugin/Traits/SlackNotifierTrait.php
+++ b/src/Robo/Plugin/Traits/SlackNotifierTrait.php
@@ -98,7 +98,6 @@ trait SlackNotifierTrait
         }
         // Determine if we are building a base preview.
         if (getenv('TUGBOAT_PREVIEW_ID') !== getenv('TUGBOAT_BASE_PREVIEW_ID')) {
-            $this->say('No Tugboat base preview found.');
             return false;
         }
         return true;


### PR DESCRIPTION
## Description
Removed potentially confusing log message.

## Motivation / Context
When viewing Tugboat logs, the message "No Tugboat base preview found." could be misinterpreted when in fact we are just trying to determine if the current preview is a base preview or not, not whether one exists.

I determined that even if we rewrote the message, it probably would not be useful to show up in the logs, so I removed it.

## Testing Instructions / How This Has Been Tested
Review PR.

## Screenshots
![CleanShot 2022-12-27 at 14 04 21@2x](https://user-images.githubusercontent.com/20355/209711786-ba68eb9d-f2d4-4e02-b86d-172046df37ad.png)
