### PR TITLE
Implemented GitHub Status check.

### DIFF
--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -17,7 +17,7 @@ class CICommands extends Tasks
      *
      * @var string
      */
-    protected const PHPCS_DEFAULT_PHP_VERSION = '8.0';
+    protected const PHPCS_DEFAULT_PHP_VERSION = '8.1';
 
     /**
      * A comma separated list of the file extensions PHPCS should check.
@@ -152,6 +152,9 @@ class CICommands extends Tasks
         $stack->exec("vendor/bin/$phpBinary --standard=$this->phpcsStandards --extensions=$this->phpcsCheckExtensions \
                 --ignore=$this->phpcsIgnorePaths $this->customCodePaths");
         // Check for PHP version compatibility.
+        // The trailing dash after the version runs checks for the specified
+        // version and above.
+        // @see https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
         $stack->exec("vendor/bin/phpcs --standard=PHPCompatibility --severity=1 \
                 --ignore=$this->phpcsIgnorePaths --extensions=php,module,theme \
                 --runtime-set testVersion $this->phpcsPhpVersion- $this->customCodePaths");

--- a/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
+++ b/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
@@ -79,7 +79,10 @@ class DrupalStatusReportCommands extends Tasks
                 ->dir("$this->drupalRoot/sites/$siteDir/")
                 ->printOutput(false)
                 ->run();
-            $drushOutput = trim($result->getOutputData());
+            $drushOutput = $result->getOutputData();
+            if (!is_null($drushOutput)) {
+                $drushOutput = trim($drushOutput);
+            }
             $reportJson = json_decode($drushOutput);
             if (!is_array($reportJson) || count($reportJson) > 0) {
                 $this->say($drushOutput);

--- a/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
+++ b/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
@@ -27,6 +27,7 @@ class DrupalStatusReportCommands extends Tasks
      *
      * @var string
      */
+    // @TODO: switch to constant.
     protected $gitHubStatusCheckName = 'ci/drupal-status-report';
 
     /**
@@ -51,7 +52,8 @@ class DrupalStatusReportCommands extends Tasks
      * @param int $severity
      *   The minimum severity level to show. Defaults to 1 (warning).
      * @option set-pr-status
-     *   Use this flag in Tugboat environments to set .
+     *   Use this flag in Tugboat environments to set the GitHub status check
+     *   on the associated pull request.
      *
      * @throws \Robo\Exception\TaskException
      */
@@ -84,7 +86,10 @@ class DrupalStatusReportCommands extends Tasks
             if (!is_array($reportJson) || count($reportJson) > 0) {
                 $this->say($drushOutput);
                 if ($options['set-pr-status']) {
-                    $this->setGitHubStatusError($this->gitHubStatusCheckName);
+                    $this->setGitHubStatusError(
+                        $this->gitHubStatusCheckName,
+                        'Drupal status report shows one or more unexpected warnings or errors.'
+                    );
                 }
                 throw new TaskException(
                     $this,
@@ -95,7 +100,8 @@ class DrupalStatusReportCommands extends Tasks
 
         $this->say('Drupal status report(s) show no unexpected warnings or errors.');
         if ($options['set-pr-status']) {
-            $this->setGitHubStatusSuccess($this->gitHubStatusCheckName);
+            $checkDescription = 'Drupal status report shows no unexpected warnings or errors.';
+            $this->setGitHubStatusSuccess($this->gitHubStatusCheckName, $checkDescription);
         }
     }
 }

--- a/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
+++ b/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
@@ -79,10 +79,7 @@ class DrupalStatusReportCommands extends Tasks
                 ->dir("$this->drupalRoot/sites/$siteDir/")
                 ->printOutput(false)
                 ->run();
-            $drushOutput = $result->getOutputData();
-            if (!is_null($drushOutput)) {
-                $drushOutput = trim($drushOutput);
-            }
+            $drushOutput = trim($result->getOutputData());
             $reportJson = json_decode($drushOutput);
             if (!is_array($reportJson) || count($reportJson) > 0) {
                 $this->say($drushOutput);

--- a/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
+++ b/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
@@ -16,19 +16,18 @@ class DrupalStatusReportCommands extends Tasks
     use GitHubStatusTrait;
 
     /**
+     * The name of the GitHub status check, if set.
+     *
+     * @var string
+     */
+    protected const GITHUB_STATUS_CHECK_NAME = 'ci/drupal-status-report';
+
+    /**
      * Drupal root directory.
      *
      * @var string
      */
     protected $drupalRoot;
-
-    /**
-     * The name of the GitHub status check, if set.
-     *
-     * @var string
-     */
-    // @TODO: switch to constant.
-    protected $gitHubStatusCheckName = 'ci/drupal-status-report';
 
     /**
      * Class constructor.
@@ -63,7 +62,7 @@ class DrupalStatusReportCommands extends Tasks
         array $options = ['set-pr-status' => false]
     ): void {
         if ($options['set-pr-status']) {
-            $this->setGitHubStatusPending($this->gitHubStatusCheckName);
+            $this->setGitHubStatusPending(self::GITHUB_STATUS_CHECK_NAME);
         }
         $sites = explode(',', $siteDirs);
         foreach ($sites as $siteDir) {
@@ -87,7 +86,7 @@ class DrupalStatusReportCommands extends Tasks
                 $this->say($drushOutput);
                 if ($options['set-pr-status']) {
                     $this->setGitHubStatusError(
-                        $this->gitHubStatusCheckName,
+                        self::GITHUB_STATUS_CHECK_NAME,
                         'Drupal status report shows one or more unexpected warnings or errors.'
                     );
                 }
@@ -101,7 +100,7 @@ class DrupalStatusReportCommands extends Tasks
         $this->say('Drupal status report(s) show no unexpected warnings or errors.');
         if ($options['set-pr-status']) {
             $checkDescription = 'Drupal status report shows no unexpected warnings or errors.';
-            $this->setGitHubStatusSuccess($this->gitHubStatusCheckName, $checkDescription);
+            $this->setGitHubStatusSuccess(self::GITHUB_STATUS_CHECK_NAME, $checkDescription);
         }
     }
 }

--- a/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
+++ b/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
@@ -61,6 +61,8 @@ class DrupalStatusReportCommands extends Tasks
         $severity = 1,
         array $options = ['set-pr-status' => false]
     ): void {
+        $this->io()->title('drupal status report.');
+
         if ($options['set-pr-status']) {
             $this->setGitHubStatusPending(self::GITHUB_STATUS_CHECK_NAME);
         }

--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -56,6 +56,8 @@ class ValidateConfigCommands extends Tasks
      */
     public function validateDrupalConfig($siteDirs = 'default', array $options = ['set-pr-status' => false]): void
     {
+        $this->io()->title('validate drupal configuration.');
+
         if ($options['set-pr-status']) {
             $this->setGitHubStatusPending(self::GITHUB_STATUS_CHECK_NAME);
         }

--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -5,12 +5,22 @@ namespace Usher\Robo\Plugin\Commands;
 use DrupalFinder\DrupalFinder;
 use Robo\Exception\TaskException;
 use Robo\Tasks;
+use Usher\Robo\Plugin\Traits\GitHubStatusTrait;
 
 /**
  * Robo commands related to changing development modes.
  */
 class ValidateConfigCommands extends Tasks
 {
+    use GitHubStatusTrait;
+
+    /**
+     * The name of the GitHub status check, if set.
+     *
+     * @var string
+     */
+    protected const GITHUB_STATUS_CHECK_NAME = 'ci/configuration-check';
+
     /**
      * Drupal root directory.
      *
@@ -35,28 +45,43 @@ class ValidateConfigCommands extends Tasks
     /**
      * Validate Drupal configuration status.
      *
-     * @param string $siteDir
-     *   The Drupal site directory.
-     *
+     * @param string $siteDirs
+     *   A comma separated list of Drupal site directories.
+     * @option set-pr-status
+     *   Use this flag in Tugboat environments to set the GitHub status check
+     *   on the associated pull request.
      * @aliases vdc
      *
      * @throws \Robo\Exception\TaskException
      */
-    public function validateDrupalConfig($siteDir = 'default'): void
+    public function validateDrupalConfig($siteDirs = 'default', array $options = ['set-pr-status' => false]): void
     {
-        $result = $this->taskExec("$this->drupalRoot/../vendor/bin/drush config:status --format=json")
-            ->dir("$this->drupalRoot/sites/$siteDir/")
-            ->printOutput(false)
-            ->run();
-        $drushOutput = trim($result->getOutputData());
-        $configJson = json_decode($drushOutput);
-        if (!is_array($configJson) || count($configJson) > 0) {
-            $this->say($drushOutput);
-            throw new TaskException(
-                $this,
-                'Drupal database configuration does not match the tracked file system configuration.'
-            );
+        if ($options['set-pr-status']) {
+            $this->setGitHubStatusPending(self::GITHUB_STATUS_CHECK_NAME);
         }
+        $sites = explode(',', $siteDirs);
+        foreach ($sites as $siteDir) {
+            $result = $this->taskExec("$this->drupalRoot/../vendor/bin/drush config:status --format=json")
+                ->dir("$this->drupalRoot/sites/$siteDir/")
+                ->printOutput(false)
+                ->run();
+            $drushOutput = trim($result->getOutputData());
+            $configJson = json_decode($drushOutput);
+            if (!is_array($configJson) || count($configJson) > 0) {
+                $this->say($drushOutput);
+                if ($options['set-pr-status']) {
+                    $this->setGitHubStatusError(self::GITHUB_STATUS_CHECK_NAME, 'Drupal config validation failed!');
+                }
+                throw new TaskException(
+                    $this,
+                    'Drupal database configuration does not match the tracked file system configuration.'
+                );
+            }
+        }
+
         $this->say('Drupal database configuration matches the tracked file system configuration.');
+        if ($options['set-pr-status']) {
+            $this->setGitHubStatusSuccess(self::GITHUB_STATUS_CHECK_NAME, 'Drupal config validation passed!');
+        }
     }
 }

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -78,7 +78,7 @@ trait GitHubStatusTrait
     private function setGitHubStatus(
         string $state,
         string $gitHubCheckName,
-        string $checkDescription = '',
+        string $checkDescription = ''
     ): void {
         $tugboatPreviewID = getenv('TUGBOAT_PREVIEW_ID');
         $tugboatPreviewSHA = getenv('TUGBOAT_PREVIEW_SHA');

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -130,7 +130,6 @@ trait GitHubStatusTrait
                     'X-GitHub-Api-Version' => '2022-11-28',
                 ],
                 'body' => json_encode($body),
-                'debug' => true,
             ]);
         } catch (RequestException $exception) {
             $this->yell('GitHub status request failed.');

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -12,6 +12,21 @@ use Robo\Result;
 trait GitHubStatusTrait
 {
     /**
+     * The error value when setting a GitHub check status.
+     */
+    protected const CHECK_STATUS_ERROR = 'error';
+
+    /**
+     * The pending value when setting a GitHub check status.
+     */
+    protected const CHECK_STATUS_PENDING = 'pending';
+
+    /**
+     * The success value when setting a GitHub check status.
+     */
+    protected const CHECK_STATUS_SUCCESS = 'success';
+
+    /**
      * The GitHub API Base URL.
      *
      * @var string
@@ -34,7 +49,7 @@ trait GitHubStatusTrait
     protected function setGitHubStatusPending(string $gitHubCheckName): void
     {
         $this->say('Setting pending status.');
-        $this->setGitHubStatus('pending', $gitHubCheckName);
+        $this->setGitHubStatus(self::CHECK_STATUS_PENDING, $gitHubCheckName);
     }
 
     /**
@@ -47,7 +62,7 @@ trait GitHubStatusTrait
     {
         $this->say('Setting success status.');
         $checkDescription = 'Drupal status report shows no unexpected warnings or errors.';
-        $this->setGitHubStatus('success', $gitHubCheckName, $checkDescription);
+        $this->setGitHubStatus(self::CHECK_STATUS_SUCCESS, $gitHubCheckName, $checkDescription);
     }
 
     /**
@@ -60,7 +75,7 @@ trait GitHubStatusTrait
     {
         $this->say('Setting failure status.');
         $checkDescription = 'Drupal status report shows one or more unexpected warnings or errors.';
-        $this->setGitHubStatus('error', $gitHubCheckName, $checkDescription);
+        $this->setGitHubStatus(self::CHECK_STATUS_ERROR, $gitHubCheckName, $checkDescription);
     }
 
     /**

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -13,18 +13,24 @@ trait GitHubStatusTrait
 {
     /**
      * The error value when setting a GitHub check status.
+     *
+     * @var string
      */
-    protected const CHECK_STATUS_ERROR = 'error';
+    protected $checkStatusError = 'error';
 
     /**
      * The pending value when setting a GitHub check status.
+     *
+     * @var string
      */
-    protected const CHECK_STATUS_PENDING = 'pending';
+    protected $checkStatusPending = 'pending';
 
     /**
      * The success value when setting a GitHub check status.
+     *
+     * @var string
      */
-    protected const CHECK_STATUS_SUCCESS = 'success';
+    protected $checkStatusSuccess = 'success';
 
     /**
      * The GitHub API Base URL.
@@ -49,7 +55,7 @@ trait GitHubStatusTrait
     protected function setGitHubStatusPending(string $gitHubCheckName): void
     {
         $this->say('Setting pending status.');
-        $this->setGitHubStatus(self::CHECK_STATUS_PENDING, $gitHubCheckName);
+        $this->setGitHubStatus($this->checkStatusPending, $gitHubCheckName);
     }
 
     /**
@@ -62,7 +68,7 @@ trait GitHubStatusTrait
     {
         $this->say('Setting success status.');
         $checkDescription = 'Drupal status report shows no unexpected warnings or errors.';
-        $this->setGitHubStatus(self::CHECK_STATUS_SUCCESS, $gitHubCheckName, $checkDescription);
+        $this->setGitHubStatus($this->checkStatusSuccess, $gitHubCheckName, $checkDescription);
     }
 
     /**
@@ -75,7 +81,7 @@ trait GitHubStatusTrait
     {
         $this->say('Setting failure status.');
         $checkDescription = 'Drupal status report shows one or more unexpected warnings or errors.';
-        $this->setGitHubStatus(self::CHECK_STATUS_ERROR, $gitHubCheckName, $checkDescription);
+        $this->setGitHubStatus($this->checkStatusError, $gitHubCheckName, $checkDescription);
     }
 
     /**

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -129,7 +129,7 @@ trait GitHubStatusTrait
                     'Authorization' => "Bearer $gitHubAccessToken",
                     'X-GitHub-Api-Version' => '2022-11-28',
                 ],
-                'body' => json_encode($payload),
+                'body' => $body,
                 'debug' => true,
             ]);
         } catch (RequestException $exception) {

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -100,7 +100,7 @@ trait GitHubStatusTrait
      *
      * @see https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
      */
-    private function setGitHubStatus(
+    protected function setGitHubStatus(
         string $state,
         string $gitHubCheckName,
         string $checkDescription = ''
@@ -113,13 +113,13 @@ trait GitHubStatusTrait
         $githubStatusUrl = "$this->githuApiBaseUrl/repos/$gitHubOrg/$gitHubRepo/statuses/$tugboatPreviewSHA";
 
         $gitHubAccessToken = getenv('GITHUB_ACCESS_TOKEN');
-        $payload = [
+        $body = [
             'state' => $state,
-            'context', "ci\\$gitHubCheckName",
+            'context', $gitHubCheckName,
         ];
         if (strlen($checkDescription) > 0) {
-            $payload['description'] = $checkDescription;
-            $payload['target_url'] = "$this->tugboatDashboardUrl/$tugboatPreviewID";
+            $body['description'] = $checkDescription;
+            $body['target_url'] = "$this->tugboatDashboardUrl/$tugboatPreviewID";
         }
         try {
             $client = new Client(['timeout' => 5]);
@@ -130,6 +130,7 @@ trait GitHubStatusTrait
                     'X-GitHub-Api-Version' => '2022-11-28',
                 ],
                 'body' => json_encode($payload),
+                'debug' => true,
             ]);
         } catch (RequestException $exception) {
             $this->yell('GitHub status request failed.');

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Usher\Robo\Plugin\Traits;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Robo\Result;
+
+/**
+ * Trait to allow setting of status checks on GitHub PRs from Tugboat.
+ */
+trait GitHubStatusTrait
+{
+    /**
+     * The GitHub API Base URL.
+     *
+     * @var string
+     */
+    protected $githuApiBaseUrl = 'https://api.github.com';
+
+    /**
+     * The Tugboat dashboard URL.
+     *
+     * @var string
+     */
+    protected $tugboatDashboardUrl = 'https://dashboard.tugboatqa.com';
+
+    /**
+     * Set GitHub PR status check to pending.
+     *
+     * @param string $gitHubCheckName
+     *   The name of the status check.
+     */
+    protected function setGitHubStatusPending(string $gitHubCheckName): void
+    {
+        $this->say('Setting pending status.');
+        $this->setGitHubStatus('pending', $gitHubCheckName);
+    }
+
+    /**
+     * Set GitHub PR status check to success.
+     *
+     * @param string $gitHubCheckName
+     *   The name of the status check.
+     */
+    protected function setGitHubStatusSuccess(string $gitHubCheckName): void
+    {
+        $this->say('Setting success status.');
+        $checkDescription = 'Drupal status report shows no unexpected warnings or errors.';
+        $this->setGitHubStatus('success', $gitHubCheckName, $checkDescription);
+    }
+
+    /**
+     * Set GitHub PR status check to error.
+     *
+     * @param string $gitHubCheckName
+     *   The name of the status check.
+     */
+    protected function setGitHubStatusError(string $gitHubCheckName): void
+    {
+        $this->say('Setting failure status.');
+        $checkDescription = 'Drupal status report shows one or more unexpected warnings or errors.';
+        $this->setGitHubStatus('error', $gitHubCheckName, $checkDescription);
+    }
+
+    /**
+     * Set GitHub PR status check.
+     *
+     * @param string $state
+     *   The state string.
+     * @param string $gitHubCheckName
+     *   The name of the status check.
+     * @param string $checkDescription
+     *   The descriptive text to set on the check.
+     *
+     * @see https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
+     */
+    private function setGitHubStatus(
+        string $state,
+        string $gitHubCheckName,
+        string $checkDescription = '',
+    ): void {
+        $tugboatPreviewID = getenv('TUGBOAT_PREVIEW_ID');
+        $tugboatPreviewSHA = getenv('TUGBOAT_PREVIEW_SHA');
+        $gitHubOrg = getenv('TUGBOAT_GITHUB_OWNER');
+        $gitHubRepo = getenv('TUGBOAT_GITHUB_REPO');
+
+        $githubStatusUrl = "$this->githuApiBaseUrl/repos/$gitHubOrg/$gitHubRepo/statuses/$tugboatPreviewSHA";
+
+        $gitHubAccessToken = getenv('GITHUB_ACCESS_TOKEN');
+        $payload = [
+            'state' => $state,
+            'context', "ci\\$gitHubCheckName",
+        ];
+        if (strlen($checkDescription) > 0) {
+            $payload['description'] = $checkDescription;
+            $payload['target_url'] = "$this->tugboatDashboardUrl/$tugboatPreviewID";
+        }
+        try {
+            $client = new Client(['timeout' => 5]);
+            $client->post($githubStatusUrl, [
+                'headers' => [
+                    'Authorization:' => "token $gitHubAccessToken"
+                ],
+                'body' => json_encode($payload),
+            ]);
+        } catch (RequestException $exception) {
+            $this->yell('GitHub status request failed.');
+        }
+    }
+}

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -54,7 +54,7 @@ trait GitHubStatusTrait
      */
     protected function setGitHubStatusPending(string $gitHubCheckName): void
     {
-        $this->say('Setting pending status.');
+        $this->yell("Setting pending status: $gitHubCheckName");
         $this->setGitHubStatus($this->checkStatusPending, $gitHubCheckName);
     }
 
@@ -68,7 +68,8 @@ trait GitHubStatusTrait
      */
     protected function setGitHubStatusSuccess(string $gitHubCheckName, string $gitHubCheckDescription): void
     {
-        $this->say('Setting success status.');
+        $this->yell("Setting success status: $gitHubCheckName");
+        $this->say($gitHubCheckDescription);
         $this->setGitHubStatus($this->checkStatusSuccess, $gitHubCheckName, $gitHubCheckDescription);
     }
 
@@ -82,7 +83,8 @@ trait GitHubStatusTrait
      */
     protected function setGitHubStatusError(string $gitHubCheckName, string $gitHubCheckDescription): void
     {
-        $this->say('Setting failure status.');
+        $this->yell("Setting failure status: $gitHubCheckName");
+        $this->say($gitHubCheckDescription);
         $this->setGitHubStatus($this->checkStatusError, $gitHubCheckName, $gitHubCheckDescription);
     }
 

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -125,7 +125,9 @@ trait GitHubStatusTrait
             $client = new Client(['timeout' => 5]);
             $client->post($githubStatusUrl, [
                 'headers' => [
-                    'Authorization:' => "token $gitHubAccessToken"
+                    'Accept' => 'application/vnd.github+json',
+                    'Authorization' => "Bearer $gitHubAccessToken",
+                    'X-GitHub-Api-Version' => '2022-11-28',
                 ],
                 'body' => json_encode($payload),
             ]);

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -8,6 +8,9 @@ use Robo\Result;
 
 /**
  * Trait to allow setting of status checks on GitHub PRs from Tugboat.
+ *
+ * The methods in this trait will only work as epected when run in a Tugboat
+ * environment.
  */
 trait GitHubStatusTrait
 {

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -115,11 +115,11 @@ trait GitHubStatusTrait
         $gitHubAccessToken = getenv('GITHUB_ACCESS_TOKEN');
         $body = [
             'state' => $state,
-            'context', $gitHubCheckName,
+            'context' => $gitHubCheckName,
+            'target_url' => "$this->tugboatDashboardUrl/$tugboatPreviewID",
         ];
         if (strlen($checkDescription) > 0) {
             $body['description'] = $checkDescription;
-            $body['target_url'] = "$this->tugboatDashboardUrl/$tugboatPreviewID";
         }
         try {
             $client = new Client(['timeout' => 5]);
@@ -129,11 +129,12 @@ trait GitHubStatusTrait
                     'Authorization' => "Bearer $gitHubAccessToken",
                     'X-GitHub-Api-Version' => '2022-11-28',
                 ],
-                'body' => $body,
+                'body' => json_encode($body),
                 'debug' => true,
             ]);
         } catch (RequestException $exception) {
             $this->yell('GitHub status request failed.');
+            $this->say($exception->getMessage());
         }
     }
 }

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -63,12 +63,13 @@ trait GitHubStatusTrait
      *
      * @param string $gitHubCheckName
      *   The name of the status check.
+     * @param string $gitHubCheckDescription
+     *   The description text to associate with the status check.
      */
-    protected function setGitHubStatusSuccess(string $gitHubCheckName): void
+    protected function setGitHubStatusSuccess(string $gitHubCheckName, string $gitHubCheckDescription): void
     {
         $this->say('Setting success status.');
-        $checkDescription = 'Drupal status report shows no unexpected warnings or errors.';
-        $this->setGitHubStatus($this->checkStatusSuccess, $gitHubCheckName, $checkDescription);
+        $this->setGitHubStatus($this->checkStatusSuccess, $gitHubCheckName, $gitHubCheckDescription);
     }
 
     /**
@@ -76,12 +77,13 @@ trait GitHubStatusTrait
      *
      * @param string $gitHubCheckName
      *   The name of the status check.
+     * @param string $gitHubCheckDescription
+     *   The description text to associate with the status check.
      */
-    protected function setGitHubStatusError(string $gitHubCheckName): void
+    protected function setGitHubStatusError(string $gitHubCheckName, string $gitHubCheckDescription): void
     {
         $this->say('Setting failure status.');
-        $checkDescription = 'Drupal status report shows one or more unexpected warnings or errors.';
-        $this->setGitHubStatus($this->checkStatusError, $gitHubCheckName, $checkDescription);
+        $this->setGitHubStatus($this->checkStatusError, $gitHubCheckName, $gitHubCheckDescription);
     }
 
     /**


### PR DESCRIPTION
## Description
* Implemented GitHub Status check.
* Refactored Status Report and Config Validation commands to allow them to support multi-sites so that the looping does not need to occur outside of Usher (like in a Bash script.)

## Motivation / Context
* Expose this functionality to all sites using Usher.
* Reduce code duplication.


## Testing Instructions / How This Has Been Tested
Tested this branch on a [downstream PR](https://github.com/ChromaticHQ/benz-platform/pull/4560).

## Screenshots
<img width="662" alt="CleanShot 2023-02-09 at 13 25 14@2x" src="https://user-images.githubusercontent.com/20355/217904541-5e0a82b8-dca5-43b9-987d-452ded5b480c.png">

