### PR TITLE
Add cache:clear bin config before config:status check.

### DIFF
--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -63,6 +63,8 @@ class ValidateConfigCommands extends Tasks
         }
         $sites = explode(',', $siteDirs);
         foreach ($sites as $siteDir) {
+            // Clear the "config" cache bin before we verify config status to
+            // improve the accuracy of this check.
             // @see https://github.com/drush-ops/drush/pull/3861#issuecomment-453767694
             // @see https://www.drush.org/11.x/commands/cache_clear/
             $result = $this->taskExec("$this->drupalRoot/../vendor/bin/drush cache:clear bin config")->run();

--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -63,6 +63,9 @@ class ValidateConfigCommands extends Tasks
         }
         $sites = explode(',', $siteDirs);
         foreach ($sites as $siteDir) {
+            // @see https://github.com/drush-ops/drush/pull/3861#issuecomment-453767694
+            // @see https://www.drush.org/11.x/commands/cache_clear/
+            $result = $this->taskExec("$this->drupalRoot/../vendor/bin/drush cache:clear bin config")->run();
             $result = $this->taskExec("$this->drupalRoot/../vendor/bin/drush config:status --format=json")
                 ->dir("$this->drupalRoot/sites/$siteDir/")
                 ->printOutput(false)


### PR DESCRIPTION
## Description
Add `cache:clear bin config` before `config:status` check

## Motivation / Context
Attempting to solve edge cases where config:status is showing a diff where we do not believe one exists.

## Testing Instructions / How This Has Been Tested
TK.