### PR TITLE
Created RoboConfigTrait to abstract logic related to retrieving robo.yml config

### DIFF
--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -23,61 +23,12 @@ class CICommands extends Tasks
     protected const PHPCS_DEFAULT_PHP_VERSION = '8.1';
 
     /**
-     * A comma separated list of the file extensions PHPCS should check.
-     *
-     * @var string
-     */
-    protected $phpcsCheckExtensions;
-
-    /**
-     * A comma separated list of the paths PHPCS should ignore.
-     *
-     * @var string
-     */
-    protected $phpcsIgnorePaths;
-
-    /**
-     * A space separated list of custom code paths.
-     *
-     * @var string
-     */
-    protected $customCodePaths;
-
-    /**
-     * A comma separated list of PHPCS standards.
-     *
-     * @var string
-     */
-    protected $phpcsStandards;
-
-    /**
-     * The PHP version to lint against for support.
-     *
-     * @var string
-     */
-    protected $phpcsPhpVersion;
-
-    /**
-     * Boolean indicating whether Twig files should be linted.
-     *
-     * @var bool
-     */
-    protected $lintTwigFiles;
-
-    /**
      * RoboFile constructor.
      */
     public function __construct()
     {
         // Treat this command like bash -e and exit as soon as there's a failure.
         $this->stopOnFail();
-
-        $this->phpcsCheckExtensions = implode(',', Robo::config()->get('phpcs_check_extensions'));
-        $this->phpcsIgnorePaths = implode(',', $this->getRoboConfigArrayFor('phpcs_ignore_paths'));
-        $this->customCodePaths = implode(' ', $this->getRoboConfigArrayFor('custom_code_paths'));
-        $this->phpcsStandards = implode(',', $this->getRoboConfigArrayFor('phpcs_standards'));
-        $this->lintTwigFiles = Robo::config()->get('twig_lint_enable') ?? true;
-        $this->phpcsPhpVersion = Robo::config()->get('phpcs_php_version', $this::PHPCS_DEFAULT_PHP_VERSION);
     }
 
     /**
@@ -105,9 +56,10 @@ class CICommands extends Tasks
      */
     public function jobRunStaticAnalysis(): Result
     {
+        $customCodePaths = $this->getCustomCodePaths();
         return $this->taskExecStack()
             ->stopOnFail()
-            ->exec("vendor/bin/phpstan analyse --memory-limit=1G $this->customCodePaths")
+            ->exec("vendor/bin/phpstan analyse --memory-limit=1G $customCodePaths")
             ->run();
     }
 
@@ -148,25 +100,43 @@ class CICommands extends Tasks
      */
     protected function jobRunCodingStandards(bool $applyFixes = false): Result
     {
+        $customCodePaths = $this->getCustomCodePaths();
+        $phpcsStandards = implode(',', $this->getRequiredRoboConfigArrayFor('phpcs_standards'));
+        $phpcsCheckExtensions = implode(',', $this->getRequiredRoboConfigArrayFor('phpcs_check_extensions'));
+        $phpcsIgnorePaths = implode(',', $this->getRequiredRoboConfigArrayFor('phpcs_ignore_paths'));
+        $phpcsPhpVersion = Robo::config()->get('phpcs_php_version', $this::PHPCS_DEFAULT_PHP_VERSION);
+        $twigLintEnabled = Robo::config()->get('twig_lint_enable') ?? true;
+
         /** @var \Robo\Task\CommandStack $stack */
         $stack = $this->taskExecStack()->stopOnFail();
         $phpBinary = $applyFixes ? 'phpcbf' : 'phpcs';
         // General PHP linting.
-        $stack->exec("vendor/bin/$phpBinary --standard=$this->phpcsStandards --extensions=$this->phpcsCheckExtensions \
-                --ignore=$this->phpcsIgnorePaths $this->customCodePaths");
+        $stack->exec("vendor/bin/$phpBinary --standard=$phpcsStandards --extensions=$phpcsCheckExtensions \
+                --ignore=$phpcsIgnorePaths $customCodePaths");
         // Check for PHP version compatibility.
         // The trailing dash after the version runs checks for the specified
         // version and above.
         // @see https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
         $stack->exec("vendor/bin/phpcs --standard=PHPCompatibility --severity=1 \
-                --ignore=$this->phpcsIgnorePaths --extensions=php,module,theme \
-                --runtime-set testVersion $this->phpcsPhpVersion- $this->customCodePaths");
+                --ignore=$phpcsIgnorePaths --extensions=php,module,theme \
+                --runtime-set testVersion $phpcsPhpVersion- $customCodePaths");
         // Lint Twig files.
-        if ($this->lintTwigFiles) {
+        if ($twigLintEnabled == true) {
             $fixFlag = $applyFixes ? '--fix' : '';
-            $stack->exec("vendor/bin/twig-cs-fixer lint $this->customCodePaths $fixFlag");
+            $stack->exec("vendor/bin/twig-cs-fixer lint $customCodePaths $fixFlag");
         }
 
         return $stack->run();
+    }
+
+    /**
+     * Get the list of custom code paths to check.
+     *
+     * @return string
+     *   A space separated list of custom code paths.
+     */
+    protected function getCustomCodePaths(): string
+    {
+        return implode(' ', $this->getRequiredRoboConfigArrayFor('custom_code_paths'));
     }
 }

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -6,12 +6,15 @@ use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Robo;
 use Robo\Tasks;
+use Usher\Robo\Plugin\Traits\RoboConfigTrait;
 
 /**
  * Robo commands related to continuous integration.
  */
 class CICommands extends Tasks
 {
+    use RoboConfigTrait;
+
     /**
      * The default PHP version to lint against.
      *
@@ -70,9 +73,9 @@ class CICommands extends Tasks
         $this->stopOnFail();
 
         $this->phpcsCheckExtensions = implode(',', Robo::config()->get('phpcs_check_extensions'));
-        $this->phpcsIgnorePaths = implode(',', Robo::config()->get('phpcs_ignore_paths'));
-        $this->customCodePaths = implode(' ', $this->getConfigurationValues('custom_code_paths'));
-        $this->phpcsStandards = implode(',', $this->getConfigurationValues('phpcs_standards'));
+        $this->phpcsIgnorePaths = implode(',', $this->getRoboConfigArrayFor('phpcs_ignore_paths'));
+        $this->customCodePaths = implode(' ', $this->getRoboConfigArrayFor('custom_code_paths'));
+        $this->phpcsStandards = implode(',', $this->getRoboConfigArrayFor('phpcs_standards'));
         $this->lintTwigFiles = Robo::config()->get('twig_lint_enable') ?? true;
         $this->phpcsPhpVersion = Robo::config()->get('phpcs_php_version', $this::PHPCS_DEFAULT_PHP_VERSION);
     }
@@ -165,21 +168,5 @@ class CICommands extends Tasks
         }
 
         return $stack->run();
-    }
-
-    /**
-     * Get coding standard(s) to use in PHPCS checks.
-     *
-     * @return array
-     *   An array containing application custom code paths.
-     *
-     * @throws \Robo\Exception\TaskException
-     */
-    protected function getConfigurationValues(string $key): array
-    {
-        if (!is_array($configurationValues = Robo::config()->get($key))) {
-            throw new TaskException($this, "Expected Robo configuration not or malfomed present: $key");
-        }
-        return $configurationValues;
     }
 }

--- a/src/Robo/Plugin/Commands/ThemeCommands.php
+++ b/src/Robo/Plugin/Commands/ThemeCommands.php
@@ -39,7 +39,7 @@ class ThemeCommands extends Tasks
     {
         $result = $this->io()->title("theme build");
         try {
-            $themeBuildConfiguration = $this->getConfig('theme_build', $siteName);
+            $themeBuildConfiguration = $this->getSiteConfigItem('theme_build', $siteName);
         } catch (TaskException $e) {
             $this->say("'$siteName' theme_build confguration not set.");
             return $this->taskExec('echo skipping')->run();

--- a/src/Robo/Plugin/Commands/ToolingCommands.php
+++ b/src/Robo/Plugin/Commands/ToolingCommands.php
@@ -53,7 +53,7 @@ class ToolingCommands extends Tasks
     {
         $this->io()->title("Updating PHP version.");
 
-        $currentPhpVersion = $this->getRoboConfigValueFor('php_current_version');
+        $currentPhpVersion = $this->getRequiredRoboConfigStringFor('php_current_version');
         $this->say("Current PHP version: $currentPhpVersion");
         $this->say("New PHP version: $version");
         if ($currentPhpVersion == $version) {
@@ -62,7 +62,7 @@ class ToolingCommands extends Tasks
 
         $configFilePaths = array_map(
             fn(string $path): string => "$this->cwd/$path",
-            $this->getRoboConfigValueFor('php_version_config_paths')
+            $this->getRequiredRoboConfigArrayFor('php_version_config_paths')
         );
 
         $result = Result::cancelled();

--- a/src/Robo/Plugin/Commands/ToolingCommands.php
+++ b/src/Robo/Plugin/Commands/ToolingCommands.php
@@ -4,9 +4,9 @@ namespace Usher\Robo\Plugin\Commands;
 
 use Robo\Exception\TaskException;
 use Robo\Result;
-use Robo\Robo;
 use Robo\Tasks;
 use Symfony\Component\Yaml\Yaml;
+use Usher\Robo\Plugin\Traits\RoboConfigTrait;
 use Usher\Robo\Plugin\Traits\SitesConfigTrait;
 
 /**
@@ -14,6 +14,7 @@ use Usher\Robo\Plugin\Traits\SitesConfigTrait;
  */
 class ToolingCommands extends Tasks
 {
+    use RoboConfigTrait;
     use SitesConfigTrait;
 
     /**
@@ -52,7 +53,7 @@ class ToolingCommands extends Tasks
     {
         $this->io()->title("Updating PHP version.");
 
-        $currentPhpVersion = $this->getConfig('php_current_version');
+        $currentPhpVersion = $this->getRoboConfigValueFor('php_current_version');
         $this->say("Current PHP version: $currentPhpVersion");
         $this->say("New PHP version: $version");
         if ($currentPhpVersion == $version) {
@@ -61,7 +62,7 @@ class ToolingCommands extends Tasks
 
         $configFilePaths = array_map(
             fn(string $path): string => "$this->cwd/$path",
-            $this->getConfig('php_version_config_paths')
+            $this->getRoboConfigValueFor('php_version_config_paths')
         );
 
         $result = Result::cancelled();
@@ -105,23 +106,5 @@ class ToolingCommands extends Tasks
         $roboConfig = Yaml::parse(file_get_contents($roboConfigPath));
         $roboConfig[$key] = $value;
         file_put_contents($roboConfigPath, Yaml::dump($roboConfig));
-    }
-
-    /**
-     * Get Robo configuration value.
-     *
-     * @param string $key
-     *   The key of the configuration to load.
-     *
-     * @return mixed
-     *   A configuration value.
-     */
-    protected function getConfig(string $key)
-    {
-        $configValue = Robo::config()->get($key);
-        if (!isset($configValue)) {
-            throw new TaskException($this, "Key $key not found in Robo config file robo.yml.");
-        }
-        return $configValue;
     }
 }

--- a/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
+++ b/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
@@ -119,7 +119,7 @@ trait DatabaseDownloadTrait
     {
         $s3ConfigArray = ['Bucket' => $this->s3BucketForSite($siteName)];
         try {
-            $s3KeyPrefix = $this->getConfig('database_s3_key_prefix_string', $siteName);
+            $s3KeyPrefix = $this->getSiteConfigItem('database_s3_key_prefix_string', $siteName);
             $this->say("'$siteName' S3 Key prefix: '$s3KeyPrefix'");
             $s3ConfigArray['Prefix'] = $s3KeyPrefix;
         } catch (TaskException $e) {
@@ -141,7 +141,7 @@ trait DatabaseDownloadTrait
      */
     protected function s3BucketForSite(string $siteName): string
     {
-        if (!is_string($bucket = $this->getConfig('database_s3_bucket', $siteName))) {
+        if (!is_string($bucket = $this->getSiteConfigItem('database_s3_bucket', $siteName))) {
             throw new TaskException($this, "database_s3_bucket value not set for '$siteName'.");
         }
         $this->say("'$siteName' S3 bucket: $bucket");
@@ -160,7 +160,7 @@ trait DatabaseDownloadTrait
     protected function s3RegionForSite(string $siteName): string
     {
         try {
-            $region = $this->getConfig('database_s3_region', $siteName);
+            $region = $this->getSiteConfigItem('database_s3_region', $siteName);
             $this->say("'$siteName' database_s3_region set to $region.");
         } catch (TaskException $e) {
             // Set default region if one is not set.

--- a/src/Robo/Plugin/Traits/RoboConfigTrait.php
+++ b/src/Robo/Plugin/Traits/RoboConfigTrait.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Usher\Robo\Plugin\Traits;
+
+use Robo\Robo;
+use Robo\Exception\TaskException;
+
+/**
+ * Trait to provide access to Robo configuration.
+ */
+trait RoboConfigTrait
+{
+    /**
+     * Get Robo configuration array value.
+     *
+     * @param string $key
+     *   The key of the configuration to load.
+     *
+     * @return array
+     *   A configuration array.
+     */
+    protected function getRoboConfigArrayFor(string $key): array
+    {
+        $configValue = $this->getRoboConfigValueFor($key);
+        $this->validateRoboConfigValueMatchesType($configValue, 'array', $key);
+        return $configValue;
+    }
+
+    /**
+     * Get Robo configuration string value.
+     *
+     * @param string $key
+     *   The key of the configuration to load.
+     *
+     * @return string
+     *   A configuration string.
+     */
+    protected function getRoboConfigStringFor(string $key): string
+    {
+        $configValue = $this->getRoboConfigValueFor($key);
+        $this->validateRoboConfigValueMatchesType($configValue, 'string', $key);
+        return $configValue;
+    }
+
+    /**
+     * Get Robo configuration value.
+     *
+     * @param string $key
+     *   The key of the configuration to load.
+     *
+     * @return mixed
+     *   A configuration value.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    private function getRoboConfigValueFor(string $key)
+    {
+        $configValue = Robo::config()->get($key);
+        if (!isset($configValue)) {
+            throw new TaskException($this, "Key $key not found in Robo config file robo.yml.");
+        }
+        return $configValue;
+    }
+
+    /**
+     * Validate Robo configuration value type.
+     *
+     * @param mixed $configValue
+     *   The configuration value.
+     * @param string $expectedType
+     *   The type we are expecting the value to be of.
+     * @param string $key
+     *   The key of the configuration.
+     *
+     * @return bool
+     *   TRUE if configuration value matches the expected type.
+     *
+     * @throws \Robo\Exception\TaskException
+     */
+    private function validateRoboConfigValueMatchesType(mixed $configValue, string $expectedType, string $key): bool
+    {
+        $foundType = gettype($configValue);
+        if ($foundType != $expectedType) {
+            throw new TaskException(
+                $this,
+                "Key $key in Robo configuration does not match expected type: $expectedType. Found $foundType."
+            );
+        }
+        return true;
+    }
+}

--- a/src/Robo/Plugin/Traits/RoboConfigTrait.php
+++ b/src/Robo/Plugin/Traits/RoboConfigTrait.php
@@ -19,9 +19,9 @@ trait RoboConfigTrait
      * @return array
      *   A configuration array.
      */
-    protected function getRoboConfigArrayFor(string $key): array
+    protected function getRequiredRoboConfigArrayFor(string $key): array
     {
-        $configValue = $this->getRoboConfigValueFor($key);
+        $configValue = $this->getRequiredRoboConfigValueFor($key);
         $this->validateRoboConfigValueMatchesType($configValue, 'array', $key);
         return $configValue;
     }
@@ -35,10 +35,26 @@ trait RoboConfigTrait
      * @return string
      *   A configuration string.
      */
-    protected function getRoboConfigStringFor(string $key): string
+    protected function getRequiredRoboConfigStringFor(string $key): string
     {
-        $configValue = $this->getRoboConfigValueFor($key);
+        $configValue = $this->getRequiredRoboConfigValueFor($key);
         $this->validateRoboConfigValueMatchesType($configValue, 'string', $key);
+        return $configValue;
+    }
+
+    /**
+     * Get Robo configuration boolean value.
+     *
+     * @param string $key
+     *   The key of the configuration to load.
+     *
+     * @return bool
+     *   A configuration value.
+     */
+    protected function getRequiredRoboConfigBoolFor(string $key): bool
+    {
+        $configValue = $this->getRequiredRoboConfigValueFor($key);
+        $this->validateRoboConfigValueMatchesType($configValue, 'boolean', $key);
         return $configValue;
     }
 
@@ -53,11 +69,11 @@ trait RoboConfigTrait
      *
      * @throws \Robo\Exception\TaskException
      */
-    private function getRoboConfigValueFor(string $key)
+    private function getRequiredRoboConfigValueFor(string $key)
     {
         $configValue = Robo::config()->get($key);
         if (!isset($configValue)) {
-            throw new TaskException($this, "Key $key not found in Robo config file robo.yml.");
+            throw new TaskException($this, "Required key $key not found in Robo config file robo.yml.");
         }
         return $configValue;
     }

--- a/src/Robo/Plugin/Traits/RoboConfigTrait.php
+++ b/src/Robo/Plugin/Traits/RoboConfigTrait.php
@@ -93,7 +93,7 @@ trait RoboConfigTrait
      *
      * @throws \Robo\Exception\TaskException
      */
-    private function validateRoboConfigValueMatchesType(mixed $configValue, string $expectedType, string $key): bool
+    private function validateRoboConfigValueMatchesType($configValue, string $expectedType, string $key): bool
     {
         $foundType = gettype($configValue);
         if ($foundType != $expectedType) {

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -54,7 +54,7 @@ trait SitesConfigTrait
     }
 
     /**
-     * Load sites configuration.
+     * Get the configuration for an entire site.
      *
      * @param string $siteName
      *   The site name.
@@ -75,7 +75,7 @@ trait SitesConfigTrait
     }
 
     /**
-     * Get site configuration value.
+     * Get an individual site configuration value.
      *
      * @param string $key
      *   The site configuration key to load.
@@ -85,9 +85,8 @@ trait SitesConfigTrait
      * @return mixed
      *   A configuration value.
      */
-    public function getConfig($key, $siteName = 'default')
+    public function getSiteConfigItem($key, $siteName = 'default')
     {
-        // @TODO: Rename method.
         $siteConfig = $this->getSiteConfig($siteName);
         if (!isset($siteConfig[$key])) {
             throw new TaskException($this, "Key $key not found for '$siteName' in $this->sitesConfigFile.");

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -87,6 +87,7 @@ trait SitesConfigTrait
      */
     public function getConfig($key, $siteName = 'default')
     {
+        // @TODO: Rename method.
         $siteConfig = $this->getSiteConfig($siteName);
         if (!isset($siteConfig[$key])) {
             throw new TaskException($this, "Key $key not found for '$siteName' in $this->sitesConfigFile.");


### PR DESCRIPTION
## Description
* Created `RoboConfigTrait` to abstract logic related to retrieving and validating configuration stored in `robo.yml`.
* Updated commands to use this new trait.

## Motivation / Context
This began with a small code smell when I didn't like that [`getConfig()` in `ToolingCommand`](https://github.com/ChromaticHQ/usher/blob/7a6b516eedf5aa186097ce025e84f8e2fd49622e/src/Robo/Plugin/Commands/ToolingCommands.php#L119-L126) was duplicating code used elsewhere and it snowballed from there.

https://github.com/ChromaticHQ/usher/blob/7a6b516eedf5aa186097ce025e84f8e2fd49622e/src/Robo/Plugin/Commands/ToolingCommands.php#L119-L126

## Testing Instructions / How This Has Been Tested
Tests should pass.
