### PR TITLE
Update phpcsversion to use php_current_version.

### DIFF
--- a/robo.drupal.example.yml
+++ b/robo.drupal.example.yml
@@ -24,7 +24,6 @@ phpcs_ignore_paths:
   - '*/themes/*/js/'
   - '*/themes/*/node_modules'
   - '*/themes/*/libraries/'
-phpcs_php_version: '8.1'
 phpcs_standards:
   - Drupal
   - DrupalPractice

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -98,7 +98,7 @@ class CICommands extends Tasks
             separator: ',',
             array: $this->getRequiredRoboConfigArrayFor(key: 'phpcs_ignore_paths'),
         );
-        $phpcsPhpVersion = Robo::config()->get('phpcs_php_version', $this::PHPCS_DEFAULT_PHP_VERSION);
+        $phpcsPhpVersion = Robo::config()->get('php_current_version', $this::PHPCS_DEFAULT_PHP_VERSION);
         $twigLintEnabled = Robo::config()->get('twig_lint_enable') ?? true;
 
         /** @var \Robo\Task\CommandStack $stack */


### PR DESCRIPTION
## Description
Deprecate `phpcs_php_version` and rely on `php_current_version` for PHPCS as well.

## Motivation / Context
Simplification. Lowers the chance of confusion.

