### PR TITLE
Disabled MixedTypeRector.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -20,6 +21,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
+        MixedTypeRector::class,
         CountOnNullRector::class => [
             // @see https://github.com/rectorphp/rector/issues/8016
             __DIR__ . '/src/Robo/Plugin/Traits/SitesConfigTrait.php',

--- a/rector.php
+++ b/rector.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php71\Rector\FuncCall\CountOnNullRector;
+use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
-use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([


### PR DESCRIPTION
## Description
Disabled MixedTypeRector.

## Motivation / Context
I don't mind removing argument docblocks generally, but in this case robo uses them to populate help text so I think we are actually losing some valuable help info.

## Testing Instructions / How This Has Been Tested
Tests pass.