### PR TITLE
Fix invocation of Alternatives task

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,6 @@ use Rector\Set\ValueObject\SetList;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/src',
-        __DIR__ . '/tests',
     ]);
 
     // Define sets of rules.

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -144,7 +144,7 @@ class DevelopmentModeBaseCommands extends Tasks
                 continue;
             }
             $dbName = $siteName === 'default' ? 'tugboat' : $siteName;
-            $taskResult = $this->task(Alternatives::class, 'mariadb', 'mysql')->run();
+            $taskResult = $this->task(Alternatives::class, 'mariadb', ['mysql'])->run();
             if (!$taskResult->wasSuccessful()) {
                 $resultData->append($taskResult);
                 continue;


### PR DESCRIPTION
Last minute refactor didn't get tested adequately. Second argument to alternatives task must be array.

Currently tugboat deployments with latest Usher will break. This merge request fixes the issue I introduced. 