### PR TITLE
Allow projects to specify which user id to pass to drush for login.

### DIFF
--- a/.sites.config.example.yml
+++ b/.sites.config.example.yml
@@ -2,6 +2,7 @@
 default:
   database_s3_bucket: S3_BUCKET_NAME
   database_s3_key_prefix_string: prod-db-prefix
+  drush_user_login_uid: 108
   theme_build:
     - theme_path: web/themes/custom/theme1
       theme_build_commands:

--- a/.sites.config.example.yml
+++ b/.sites.config.example.yml
@@ -2,7 +2,7 @@
 default:
   database_s3_bucket: S3_BUCKET_NAME
   database_s3_key_prefix_string: prod-db-prefix
-  drush_user_login_uid: 108
+  drupal_admin_uid: 108
   theme_build:
     - theme_path: web/themes/custom/theme1
       theme_build_commands:

--- a/.sites.config.example.yml
+++ b/.sites.config.example.yml
@@ -2,7 +2,7 @@
 default:
   database_s3_bucket: S3_BUCKET_NAME
   database_s3_key_prefix_string: prod-db-prefix
-  drupal_admin_uid: 108
+  drupal_user_login_uid: 108
   theme_build:
     - theme_path: web/themes/custom/theme1
       theme_build_commands:

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -192,7 +192,7 @@ class DevelopmentModeBaseCommands extends Tasks
         string $siteDir = 'default',
     ): Result {
         $this->io()->section("create login link.");
-        $uid = $this->getSiteConfigItem(key: 'drush_user_login_uid', siteName: $siteDir, required: false) ?? 1;
+        $uid = $this->getSiteConfigItem(key: 'drupal_admin_uid', siteName: $siteDir, required: false) ?? 1;
         return $this->taskExec($environmentType)
             ->arg('drush')
             ->arg("@$siteDir.$environmentType")

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -192,10 +192,12 @@ class DevelopmentModeBaseCommands extends Tasks
         string $siteDir = 'default',
     ): Result {
         $this->io()->section("create login link.");
+        $uid = $this->getSiteConfigItem(key: 'drush_user_login_uid', siteName: $siteDir, required: false) ?? 1;
         return $this->taskExec($environmentType)
             ->arg('drush')
             ->arg("@$siteDir.$environmentType")
             ->arg('user:login')
+            ->option("--uid=$uid")
             ->dir("$this->drupalRoot/sites/$siteDir")
             ->run();
     }

--- a/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeBaseCommands.php
@@ -192,7 +192,7 @@ class DevelopmentModeBaseCommands extends Tasks
         string $siteDir = 'default',
     ): Result {
         $this->io()->section("create login link.");
-        $uid = $this->getSiteConfigItem(key: 'drupal_admin_uid', siteName: $siteDir, required: false) ?? 1;
+        $uid = $this->getDrupalSiteAdminUid(siteName: $siteDir);
         return $this->taskExec($environmentType)
             ->arg('drush')
             ->arg("@$siteDir.$environmentType")

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -11,6 +11,13 @@ use Symfony\Component\Yaml\Yaml;
 trait SitesConfigTrait
 {
     /**
+     * The default Drupal admin user ID.
+     *
+     * @var int
+     */
+    protected const DRUPAL_DEFAULT_ADMIN_UID = 1;
+
+    /**
      * Filename for a site's configuration file.
      *
      * @var string
@@ -103,5 +110,23 @@ trait SitesConfigTrait
     {
         ksort($sitesConfig);
         file_put_contents($this->sitesConfigFile, Yaml::dump($sitesConfig));
+    }
+
+    /**
+     * Get the Drupal site admin user ID.
+     *
+     * @param string $siteName
+     *   The site name.
+     *
+     * @return int
+     *   The Drupal admin user ID.
+     */
+    protected function getDrupalSiteAdminUid(string $siteName = 'default'): int
+    {
+        return $this->getSiteConfigItem(
+            key: 'drupal_admin_uid',
+            siteName: $siteName,
+            required: false,
+        ) ?? self::DRUPAL_DEFAULT_ADMIN_UID;
     }
 }

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -11,13 +11,6 @@ use Symfony\Component\Yaml\Yaml;
 trait SitesConfigTrait
 {
     /**
-     * The default Drupal admin user ID.
-     *
-     * @var int
-     */
-    protected const DRUPAL_DEFAULT_ADMIN_UID = 1;
-
-    /**
      * Filename for a site's configuration file.
      *
      * @var string
@@ -127,6 +120,8 @@ trait SitesConfigTrait
             key: 'drupal_admin_uid',
             siteName: $siteName,
             required: false,
-        ) ?? self::DRUPAL_DEFAULT_ADMIN_UID;
+            // @todo: Replace the use of '1' with a constant once we drop PHP
+            // 8.1 support.
+        ) ?? 1;
     }
 }

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -78,12 +78,17 @@ trait SitesConfigTrait
      *   The site configuration key to load.
      * @param string $siteName
      *   The site name.
+     * @param bool $required
+     *   Whether the config item is expected to always be present.
      */
-    public function getSiteConfigItem(string $key, string $siteName = 'default'): mixed
+    public function getSiteConfigItem(string $key, string $siteName = 'default', bool $required = true): mixed
     {
         $siteConfig = $this->getSiteConfig(siteName: $siteName);
         if (!isset($siteConfig[$key])) {
-            throw new TaskException($this, "Key $key not found for '$siteName' in $this->sitesConfigFile.");
+            if ($required) {
+                throw new TaskException($this, "Key $key not found for '$siteName' in $this->sitesConfigFile.");
+            }
+            return null;
         }
         return $siteConfig[$key];
     }

--- a/src/Robo/Plugin/Traits/SitesConfigTrait.php
+++ b/src/Robo/Plugin/Traits/SitesConfigTrait.php
@@ -117,7 +117,7 @@ trait SitesConfigTrait
     protected function getDrupalSiteAdminUid(string $siteName = 'default'): int
     {
         return $this->getSiteConfigItem(
-            key: 'drupal_admin_uid',
+            key: 'drupal_user_login_uid',
             siteName: $siteName,
             required: false,
             // @todo: Replace the use of '1' with a constant once we drop PHP


### PR DESCRIPTION
## Description
Allow projects to specify which user ID to pass to drush for login.

## Motivation / Context
A project where uid 1 is blocked.

## Testing Instructions / How This Has Been Tested
Tested locally.

## Screenshots
<img width="633" alt="CleanShot 2023-09-27 at 13 03 40@2x" src="https://github.com/ChromaticHQ/usher/assets/20355/77cc60e2-c74a-4280-8fb4-8df553661adc">

## Documentation
Updated `.sites.config.example.yml`