### PR TITLE
[Backport 3.x] Bump shivammathur/setup-php from 2.27.1 to 2.28.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.27.0
+        uses: shivammathur/setup-php@2.28.0
         with:
           php-version: ${{ matrix.php }}
 


### PR DESCRIPTION
## Description
[Backport 3.x] Bump shivammathur/setup-php from 2.27.1 to 2.28.0

## Motivation / Context
https://github.com/ChromaticHQ/usher/pull/182