### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Add PHP 8.3 support

## Motivation / Context
https://thephp.foundation/blog/2023/11/23/php-83/

## Testing Instructions / How This Has Been Tested
Tests should pass.