### PR TITLE
Removed skipping of CountOnNull rector rule.

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php80\Rector\FunctionLike\MixedTypeRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;

--- a/rector.php
+++ b/rector.php
@@ -20,10 +20,6 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
-        MixedTypeRector::class,
-        CountOnNullRector::class => [
-            // @see https://github.com/rectorphp/rector/issues/8016
-            __DIR__ . '/src/Robo/Plugin/Traits/SitesConfigTrait.php',
-        ],
+        MixedTypeRector::class
     ]);
 };


### PR DESCRIPTION

## Description
Removed skipping of CountOnNull rector rule.

Fixed upstream: https://github.com/rectorphp/rector-src/pull/4556

## Motivation / Context

Tests were failing because the upstream fix resolved the issue.


## Testing Instructions / How This Has Been Tested
Tests should pass.