### PR TITLE
Add ^1.0.0 version to rector/rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "guzzlehttp/guzzle": "^5.0 || ^6.0 || ^7.0",
-        "rector/rector": "^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0"
+        "rector/rector": "^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^1.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description
A recent Renovate attempt to update to `palantirnet/drupal-rector ^0.20.0` is borking and my troubleshooting found that 
`palantir/drupal-rector` requires `rector/rector ^1.0` and `usher` allows up to `0.19.0`.

(In the error message below, it reports `usher` can use up to `0.18.13` though `0.19.0` is also allowed in `composer.json`.)

```
- chromatic/usher v4.0.0 requires rector/rector ^0.16.0 || ^0.17.0 || ^0.18.0 -> satisfiable by rector/rector[0.16.0, ..., 0.18.13].
- palantirnet/drupal-rector[0.20.0, ..., 0.20.1] require rector/rector ^1.0 -> satisfiable by rector/rector[1.0.0, 1.0.1, 1.0.2, 1.0.3].
```
