### PR TITLE
Make refresh commands runnable inside container for ddev

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -236,7 +236,7 @@ class DevelopmentModeCommands extends Tasks
     ): Result {
         $this->io()->section("create login link.");
         $uid = $this->getDrupalSiteAdminUid(siteName: $siteDir);
-        if ($environmentType == 'ddev') {
+        if ($environmentType === 'ddev') {
             return $this->taskExec('drush')
                 ->arg("@$siteDir.$environmentType")
                 ->arg('user:login')

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -325,7 +325,7 @@ class DevelopmentModeCommands extends Tasks
                 "'drush deploy' command not found. Further work is necessary to support this version of Drush."
             );
         }
-            // After drush deploy, re-import the latest configuration. This includes
+        // After drush deploy, re-import the latest configuration. This includes
         // the latest configuration_split configuration. Importing this twice
         // ensures that the latter command enables and disables modules based
         // upon the most up--to-date configuration. More at:

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -142,7 +142,7 @@ class DevelopmentModeCommands extends Tasks
             $dbPath = $this->databaseDownload($siteName);
         }
 
-        $this->io()->section("importing $siteName database.");
+        $this->io()->section("refreshing $siteName database.");
         $this->say("Dropping existing database for $siteName");
         $this->taskExec('drush')
             ->arg('sql:drop')
@@ -325,25 +325,18 @@ class DevelopmentModeCommands extends Tasks
                 "'drush deploy' command not found. Further work is necessary to support this version of Drush."
             );
         }
-        // After drush deploy, import the latest configuration again. This
-        // includes the latest configuration_split configuration. Importing this
-        // twice ensures that the latter command enables and disables modules
-        // based upon the most up--to-date configuration. Additional information
-        // and discussion can be found here:
+            // After drush deploy, re-import the latest configuration. This includes
+        // the latest configuration_split configuration. Importing this twice
+        // ensures that the latter command enables and disables modules based
+        // upon the most up--to-date configuration. More at:
         // https://github.com/drush-ops/drush/issues/2449#issuecomment-708655673
 
-        // ddev command is not available inside ddev containers.
-        if ($localEnvironmentType->value == 'ddev') {
-            return $this->taskExecStack()
-                ->dir("$this->drupalRoot/sites/$siteDir")
-                ->exec("drush @$siteDir.$localEnvironmentType->value deploy --yes")
-                ->exec("drush @$siteDir.$localEnvironmentType->value config:import --yes")
-                ->run();
-        }
+        // Currently we only have one local environment type:
+        // LocalDevEnvironmentTypes::DDEV, so no need for other implementations.
         return $this->taskExecStack()
             ->dir("$this->drupalRoot/sites/$siteDir")
-            ->exec("$localEnvironmentType->value drush @$siteDir.$localEnvironmentType->value deploy --yes")
-            ->exec("$localEnvironmentType->value drush @$siteDir.$localEnvironmentType->value config:import --yes")
+            ->exec("drush @$siteDir.$localEnvironmentType->value deploy --yes")
+            ->exec("drush @$siteDir.$localEnvironmentType->value config:import --yes")
             ->run();
     }
 

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -143,13 +143,14 @@ class DevelopmentModeCommands extends Tasks
         }
 
         $this->io()->section("importing $siteName database.");
-        $this->say("Importing $dbPath");
-        $this->taskExec(LocalDevEnvironmentTypes::DDEV->value)
-            ->arg('import-db')
-            ->option('database', $siteName === 'default' ? 'db' : $siteName)
-            ->option('file', $dbPath)
+        $this->say("Dropping existing database for $siteName");
+        $this->taskExec('drush')
+            ->arg('sql:drop')
+            ->option('uri', $siteName)
+            ->option('yes')
             ->run();
-
+        $this->say("Importing $dbPath");
+        $this->_exec("zcat '$dbPath' | drush sql:cli --uri=$siteName");
         // If a database was downloaded as part of this process, delete it.
         if (!$dbPathProvidedByUser) {
             $this->deleteDatabase($dbPath);
@@ -235,6 +236,14 @@ class DevelopmentModeCommands extends Tasks
     ): Result {
         $this->io()->section("create login link.");
         $uid = $this->getDrupalSiteAdminUid(siteName: $siteDir);
+        if ($environmentType == 'ddev') {
+            return $this->taskExec('drush')
+                ->arg("@$siteDir.$environmentType")
+                ->arg('user:login')
+                ->option("--uid=$uid")
+                ->dir("$this->drupalRoot/sites/$siteDir")
+                ->run();
+        }
         return $this->taskExec($environmentType)
             ->arg('drush')
             ->arg("@$siteDir.$environmentType")
@@ -316,15 +325,24 @@ class DevelopmentModeCommands extends Tasks
                 "'drush deploy' command not found. Further work is necessary to support this version of Drush."
             );
         }
+        // After drush deploy, import the latest configuration again. This
+        // includes the latest configuration_split configuration. Importing this
+        // twice ensures that the latter command enables and disables modules
+        // based upon the most up--to-date configuration. Additional information
+        // and discussion can be found here:
+        // https://github.com/drush-ops/drush/issues/2449#issuecomment-708655673
+
+        // ddev command is not available inside ddev containers.
+        if ($localEnvironmentType->value == 'ddev') {
+            return $this->taskExecStack()
+                ->dir("$this->drupalRoot/sites/$siteDir")
+                ->exec("drush @$siteDir.$localEnvironmentType->value deploy --yes")
+                ->exec("drush @$siteDir.$localEnvironmentType->value config:import --yes")
+                ->run();
+        }
         return $this->taskExecStack()
             ->dir("$this->drupalRoot/sites/$siteDir")
             ->exec("$localEnvironmentType->value drush @$siteDir.$localEnvironmentType->value deploy --yes")
-            // Import the latest configuration again. This includes the latest
-            // configuration_split configuration. Importing this twice ensures that
-            // the latter command enables and disables modules based upon the most up
-            // to date configuration. Additional information and discussion can be
-            // found here:
-            // https://github.com/drush-ops/drush/issues/2449#issuecomment-708655673
             ->exec("$localEnvironmentType->value drush @$siteDir.$localEnvironmentType->value config:import --yes")
             ->run();
     }


### PR DESCRIPTION
As described in #204, we can't run robo refresh divorced from the host OS when using ddev because unfortunately the ddev-specific implementations are using ddev commands, which cannot be run inside the container. 

Removing the reliance on those commands and using native drupal/drush instead, allows us to run the robo refresh sequence entirely within the service container, meaning the developer doesn't have to futz with php versions, composer etc, on the host OS. 

Resolves #204 