### PR TITLE
Circumvent MariaDB’s sandbox mode on database import

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -199,7 +199,11 @@ class DevelopmentModeCommands extends Tasks
                 ->run();
             $resultData->append($taskResult);
             $this->io()->section("import $siteName database.");
-            $taskResult = $this->taskExec("zcat $dbPath | $dbDriver -h mariadb -u tugboat -ptugboat $dbName")
+            # With `tail +2`, we are temporarily stripping out the first line
+            # of the database dump to remove a sandbox command that MariaDB
+            # does not understand.
+            # See: https://mariadb.org/mariadb-dump-file-compatibility-change/
+            $taskResult = $this->taskExec("zcat $dbPath | tail +2 | $dbDriver -h mariadb -u tugboat -ptugboat $dbName")
                 ->run();
             $resultData->append($taskResult);
             $taskResult = $this->taskExec('rm')->args($dbPath)->run();


### PR DESCRIPTION
## Description

This PR is no longer necessary, but it’s staying open and in draft mode until after we update our project(s) to no longer reference this branch. Closing the PR would leave a very tempting “delete branch” button that would break our builds on any projects currently pointing to this branch.

## Motivation / Context

Related to chromatichq/benz-tickets#3861.