### PR TITLE
Fixed DrupalFinder class deprecation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan-strict-rules": "^1.5"
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "drupal/core": "*"
     }
 }

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -2,7 +2,7 @@
 
 namespace Usher\Robo\Plugin\Commands;
 
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\ResultData;
@@ -53,8 +53,7 @@ class DevelopmentModeCommands extends Tasks
         $this->stopOnFail();
 
         // Find Drupal root path.
-        $drupalFinder = new DrupalFinder();
-        $drupalFinder->locateRoot(getcwd());
+        $drupalFinder = new DrupalFinderComposerRuntime();
         $this->drupalRoot = $drupalFinder->getDrupalRoot();
         $this->vendorDirectory = $drupalFinder->getVendorDir();
         $this->devServicesPath = "$this->drupalRoot/sites/fe.development.services.yml";

--- a/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
+++ b/src/Robo/Plugin/Commands/DrupalStatusReportCommands.php
@@ -2,7 +2,7 @@
 
 namespace Usher\Robo\Plugin\Commands;
 
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use Robo\Exception\TaskException;
 use Robo\Robo;
 use Robo\Result;
@@ -39,8 +39,7 @@ class DrupalStatusReportCommands extends Tasks
         $this->stopOnFail();
 
         // Find Drupal root path.
-        $drupalFinder = new DrupalFinder();
-        $drupalFinder->locateRoot(getcwd());
+        $drupalFinder = new DrupalFinderComposerRuntime();
         $this->drupalRoot = $drupalFinder->getDrupalRoot();
     }
 

--- a/src/Robo/Plugin/Commands/ValidateConfigCommands.php
+++ b/src/Robo/Plugin/Commands/ValidateConfigCommands.php
@@ -2,7 +2,7 @@
 
 namespace Usher\Robo\Plugin\Commands;
 
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Tasks;
@@ -38,8 +38,7 @@ class ValidateConfigCommands extends Tasks
         $this->stopOnFail();
 
         // Find Drupal root path.
-        $drupalFinder = new DrupalFinder();
-        $drupalFinder->locateRoot(getcwd());
+        $drupalFinder = new DrupalFinderComposerRuntime();
         $this->drupalRoot = $drupalFinder->getDrupalRoot();
     }
 


### PR DESCRIPTION
## Description
Fixed DrupalFinder class deprecation.

## Motivation / Context
Closes gh-210.

## Testing Instructions / How This Has Been Tested
CI tests pass but ideally, this should be tested with a real Drupal environment.