### PR TITLE
Force inclusion of symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "phpstan/extension-installer": "^1.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "guzzlehttp/guzzle": "^5.0 || ^6.0 || ^7.0",
-        "rector/rector": "^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^1.0.0"
+        "rector/rector": "^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^1.0.0",
+        "symfony/yaml": "^6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Description

While usually usher is used together with Drupal, and most Drupal installations require symfony/yaml, best practice (and in order to pass php tests) would be for usher to include all critical dependencies explicitly. 

This merge request requires symfony/yaml to ensure its inclusion in the autoloader.
<!-- Describe your changes in detail. The sections suggested are intended to make -->
<!-- it easy to create a descriptive PR that is easy to review. Change as needed! -->

## Motivation / Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes or is related to an open issue, link to the issue here. -->

## Testing Instructions / How This Has Been Tested
<!-- Describe how you tested your changes and/or how a reviewer can test your changes. -->

## Screenshots
<!-- Would including screenshots be helpful to the reviewer? -->

## Documentation
<!-- Do any of the changes warrant documentation updates? -->
