### PR TITLE
Do not force a cache rebuild after a database refresh

### DIFF
--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -203,14 +203,6 @@ class DevelopmentModeCommands extends Tasks
             $resultData->append($taskResult);
             $taskResult = $this->taskExec('rm')->args($dbPath)->run();
             $resultData->append($taskResult);
-
-            if (!$this->drupalVersionIsD7($this->drupalRoot)) {
-                $taskResult = $this->taskExec("$this->vendorDirectory/bin/drush")
-                    ->arg('cache:rebuild')
-                    ->dir("$this->drupalRoot/sites/$siteName")
-                    ->run();
-                $resultData->append($taskResult);
-            }
         }
 
         return $resultData;


### PR DESCRIPTION
A cache rebuild forces a full bootstrap and any new code that relies on an unenabled module will fail the build.

Resolves #220

