### PR TITLE
Handle change in PHPUnit invocation syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     },
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^1.5 || ^2.0",
-        "drupal/core": "*"
+        "drupal/core": "*",
+        "phpunit/phpunit": "*"
     }
 }

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -40,6 +40,9 @@ class CICommands extends Tasks
      * Command to run unit tests.
      *
      * @aliases punit
+     *
+     * @todo Remove support for PHPUnit --verbose syntax in next major Usher
+     * version.
      */
     public function jobRunUnitTests(): Result
     {

--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -23,6 +23,11 @@ class CICommands extends Tasks
     protected const PHPCS_DEFAULT_PHP_VERSION = '8.1';
 
     /**
+     * The maximum PHPUnit version that allows the --verbose flag.
+     */
+    protected const PHPUNIT_MAX_VERSION_WITH_VERBOSE_FLAG = 9;
+
+    /**
      * RoboFile constructor.
      */
     public function __construct()
@@ -38,6 +43,16 @@ class CICommands extends Tasks
      */
     public function jobRunUnitTests(): Result
     {
+        exec("phpunit --version | awk '{print $2}'", $output, $result_code);
+        if ($result_code === 0) {
+            $major_version = (int) $output[0];
+            if ($major_version > self::PHPUNIT_MAX_VERSION_WITH_VERBOSE_FLAG) {
+                return $this->taskExec(
+                    'XDEBUG_MODE=coverage vendor/bin/phpunit --debug --log-events-verbose-text phpunit.log'
+                )->run();
+            }
+        }
+        // Default to old PHPUnit verbose flag syntax.
         return $this->taskExec('XDEBUG_MODE=coverage vendor/bin/phpunit --debug --verbose')->run();
     }
 


### PR DESCRIPTION
## Description

This merge request allows for invoking `robo job:run-unit-tests` across PHPUnit version < 10 and > 10. PHPUnit 10 dropped support for the `--verbose` flag. 

## Motivation / Context
Resolves #233 
Resolves #234 

## Testing Instructions / How This Has Been Tested
Require this branch of Usher in your project and run `robo job:run-unit-tests`.  It would be especially good to test this in a project that uses PHPUnit 9 (or lower) and one that uses PHPUnit v 10 (or higher). 

