### PR TITLE
Potentially speed up db imports using drush sql:connect instead of drush sql:cli

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
             "phpstan/extension-installer": true,
             "php-http/discovery": true,
             "drupal/core-composer-scaffold": true
-        }
+        },
+        "optimize-autoloader": true
     },
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^1.5 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,7 @@
             "phpstan/extension-installer": true,
             "php-http/discovery": true,
             "drupal/core-composer-scaffold": true
-        },
-        "optimize-autoloader": true
+        }
     },
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^1.5 || ^2.0",

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -257,23 +257,10 @@ class DevelopmentModeCommands extends Tasks
                 ->run();
             $resultData->append($taskResult);
             $io->section("import $siteName database.");
-            // Unzip the sql data file.
-            $taskResult = $this->taskExec('gunzip')
-                ->option('--force')
-                ->arg($dbPath)
+            $taskResult = $this->taskExec("zcat $dbPath | $dbDriver -h mariadb -u tugboat -ptugboat $dbName")
                 ->run();
             $resultData->append($taskResult);
-            // Strip off the .gz extension for import.
-            $importFile = substr($dbPath, 0, -3);
-            $taskResult = $this->taskExec($dbDriver)
-                ->option('-h', 'mariadb')
-                ->option('-u', 'tugboat')
-                ->option('-ptugboat')
-                ->arg($dbName)
-                ->rawArg("< $importFile")
-                ->run();
-            $resultData->append($taskResult);
-            $taskResult = $this->deleteDataFile($importFile);
+            $taskResult = $this->deleteDataFile($dbPath);
             $resultData->append($taskResult);
         }
 

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -138,6 +138,8 @@ class DevelopmentModeCommands extends Tasks
      *   The Drupal site name.
      * @option db
      *   Provide a path to a database dump to be used instead of downloading the latest dump.
+     *
+     * The data file to be imported must be either a gzipped or non-gzipped sql file.
      */
     public function databaseRefreshDdev(
         ConsoleIO $io,
@@ -167,6 +169,21 @@ class DevelopmentModeCommands extends Tasks
             }
         }
 
+        if (str_ends_with($dbPath, 'sql.gz')) {
+            $importFile = substr($dbPath, 0, -3);
+            $gzip = TRUE;
+        }
+        elseif (str_ends_with($dbPath, '.sql')) {
+            $importFile = $dbPath;
+            $gzip = FALSE;
+        }
+        else {
+            throw new TaskException(
+                $this,
+                'Data import file must either be a .sql file or a .sql.gz file.',
+            );
+        }
+
         $io->section("refreshing $siteName database.");
         $io->say("Dropping existing database for $siteName");
         $this->taskExec('drush')
@@ -174,11 +191,23 @@ class DevelopmentModeCommands extends Tasks
             ->option('uri', $siteName)
             ->option('yes')
             ->run();
-        $io->say("Importing $dbPath");
-        $this->_exec("zcat '$dbPath' | drush sql:cli --uri=$siteName");
         // If a database was downloaded as part of this process, delete it.
-        if (!$dbPathProvidedByUser) {
-            $this->deleteDatabase($dbPath);
+        if ($dbPathProvidedByUser) {
+            if ($gzip) {
+                $this->_exec("gunzip --force --keep '$dbPath'");
+            }
+        }
+        else {
+            if ($gzip) {
+                $this->_exec("gunzip --force '$dbPath'");
+            }
+        }
+        $io->say('Importing data from: ' . $importFile);
+        $this->_exec('$(drush sql:connect --uri="' . $siteName . '") < "' . $importFile .'"');
+        if (!$dbPathProvidedByUser || ($dbPathProvidedByUser && $gzip)) {
+            // gunzip without --keep deletes the sql.gz file while unzipping.
+            // Delete the unzipped file.
+            $this->deleteDataFile($importFile);
         }
 
         return $this->drushDeployWith(

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -257,10 +257,23 @@ class DevelopmentModeCommands extends Tasks
                 ->run();
             $resultData->append($taskResult);
             $io->section("import $siteName database.");
-            $taskResult = $this->taskExec("zcat $dbPath | $dbDriver -h mariadb -u tugboat -ptugboat $dbName")
+            // Unzip the sql data file.
+            $taskResult = $this->taskExec('gunzip')
+                ->option('--force')
+                ->arg($dbPath)
                 ->run();
             $resultData->append($taskResult);
-            $taskResult = $this->taskExec('rm')->args($dbPath)->run();
+            // Strip off the .gz extension for import.
+            $importFile = substr($dbPath, 0, -3);
+            $taskResult = $this->taskExec($dbDriver)
+                ->option('-h', 'mariadb')
+                ->option('-u', 'tugboat')
+                ->option('-ptugboat')
+                ->arg($dbName)
+                ->rawArg("< $importFile")
+                ->run();
+            $resultData->append($taskResult);
+            $taskResult = $this->taskExec('rm')->args($importFile)->run();
             $resultData->append($taskResult);
         }
 

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -147,7 +147,8 @@ class DevelopmentModeCommands extends Tasks
         array $options = ['db' => '']
     ): Result|ResultData {
         $io->title('DDEV database refresh.');
-
+        // Tell phpstan that robo will enforce string value for $dbPath.
+        /** @var string $dbPath **/
         ['db' => $dbPath] = $options;
         // Track whether a database path was provided by the user or not.
         $dbPathProvidedByUser = $dbPath !== '';
@@ -171,13 +172,11 @@ class DevelopmentModeCommands extends Tasks
 
         if (str_ends_with($dbPath, 'sql.gz')) {
             $importFile = substr($dbPath, 0, -3);
-            $gzip = TRUE;
-        }
-        elseif (str_ends_with($dbPath, '.sql')) {
+            $gzip = true;
+        } elseif (str_ends_with($dbPath, '.sql')) {
             $importFile = $dbPath;
-            $gzip = FALSE;
-        }
-        else {
+            $gzip = false;
+        } else {
             throw new TaskException(
                 $this,
                 'Data import file must either be a .sql file or a .sql.gz file.',
@@ -191,20 +190,22 @@ class DevelopmentModeCommands extends Tasks
             ->option('uri', $siteName)
             ->option('yes')
             ->run();
-        // If a database was downloaded as part of this process, delete it.
-        if ($dbPathProvidedByUser) {
-            if ($gzip) {
+        if ($gzip) {
+            if ($dbPathProvidedByUser) {
+                // Keep the provided file.
                 $this->_exec("gunzip --force --keep '$dbPath'");
-            }
-        }
-        else {
-            if ($gzip) {
+            } else {
+                // Delete the downloaded original gzip file.
                 $this->_exec("gunzip --force '$dbPath'");
             }
         }
         $io->say('Importing data from: ' . $importFile);
-        $this->_exec('$(drush sql:connect --uri="' . $siteName . '") < "' . $importFile .'"');
-        if (!$dbPathProvidedByUser || ($dbPathProvidedByUser && $gzip)) {
+        $this->_exec('$(drush sql:connect --uri="' . $siteName . '") < "' . $importFile . '"');
+        // If the file was not provided by the user (ie downloaded), delete it.
+        // Gzip files unzipped without --keep will already be removed.
+        // Therefore we only need to delete the sql file, and then only if it
+        // was not provided by the user.
+        if (!$dbPathProvidedByUser || $gzip) {
             // gunzip without --keep deletes the sql.gz file while unzipping.
             // Delete the unzipped file.
             $this->deleteDataFile($importFile);

--- a/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
+++ b/src/Robo/Plugin/Commands/DevelopmentModeCommands.php
@@ -273,7 +273,7 @@ class DevelopmentModeCommands extends Tasks
                 ->rawArg("< $importFile")
                 ->run();
             $resultData->append($taskResult);
-            $taskResult = $this->taskExec('rm')->args($importFile)->run();
+            $taskResult = $this->deleteDataFile($importFile);
             $resultData->append($taskResult);
         }
 

--- a/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
+++ b/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
@@ -244,7 +244,7 @@ trait DatabaseDownloadTrait
     /**
      * Delete the specified database.
      */
-    protected function deleteDatabase(string $dbPath): Result
+    protected function deleteDataFile(string $dbPath): Result
     {
         $this->say("Deleting $dbPath");
         return $this->taskExec('rm')->args($dbPath)->run();


### PR DESCRIPTION
## Description
This changes the way data is imported during a dev db refresh from using STDIN pipe to load unzipped data into Drupal to reading an unzipped sql file into a db client.

This is supposed to be faster.

## Motivation / Context
Performance: Resolves #239

If we find that this greatly improves the import, we may expand this merge request to also include an optimization for the Tugboat refresh command.

## Testing Instructions / How This Has Been Tested

### Performance
Before testing, do three refreshes using the 5.x or latest of usher and get a time to import average. In order to minimize external factors, close all running software other than DDEV, Terminal and OrbStack (or docker composer). Also, provide the db file, rather than downloading it each time from AWS to remove network latency from the testing.

Then require this branch and run three more and see if there is a statistically significant improvement. 

How to use this branch rather than the Usher release:

`ddev composer require "chromatic/usher:dev-239-sql-connect"`

There are further improvements in this branch that could also be tested:
1. Test while providing an already unzipped sql file on the command line
2. Test without providing a file (downloading from AWS)
3. Test while providing an invalid file, and see that we are now failing the task with an exception.