### PR TITLE
fix: use explicit nullable types for PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
 
     steps:
       - uses: actions/checkout@v6

--- a/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
+++ b/src/Robo/Plugin/Traits/DatabaseDownloadTrait.php
@@ -74,7 +74,7 @@ trait DatabaseDownloadTrait
                 $objects = $s3->listObjectsV2($requestConfig);
             } catch (\Exception $e) {
                 $io->error($e->getMessage());
-                throw new AbortTasksException('Unable to access AWS S3. Giving up.');
+                throw new AbortTasksException('Unable to access AWS S3. Giving up.', $e->getCode(), $e);
             }
         }
         $objects = iterator_to_array($objects);

--- a/src/Robo/Plugin/Traits/GitHubStatusTrait.php
+++ b/src/Robo/Plugin/Traits/GitHubStatusTrait.php
@@ -74,7 +74,7 @@ trait GitHubStatusTrait
     protected function setGitHubStatusSuccess(
         string $gitHubCheckName,
         string $gitHubCheckDescription,
-        string $gitHubCheckUrl = null,
+        ?string $gitHubCheckUrl = null,
     ): void {
         $this->yell("Setting success status on GitHub check: $gitHubCheckName");
         $this->say($gitHubCheckDescription);
@@ -94,7 +94,7 @@ trait GitHubStatusTrait
     protected function setGitHubStatusError(
         string $gitHubCheckName,
         string $gitHubCheckDescription,
-        string $gitHubCheckUrl = null,
+        ?string $gitHubCheckUrl = null,
     ): void {
         $this->yell("Setting failure status on GitHub check: $gitHubCheckName");
         $this->say($gitHubCheckDescription);
@@ -119,7 +119,7 @@ trait GitHubStatusTrait
         string $state,
         string $gitHubCheckName,
         string $checkDescription = '',
-        string $targetUrl = null,
+        ?string $targetUrl = null,
     ): void {
         $tugboatPreviewID = getenv('TUGBOAT_PREVIEW_ID');
         $tugboatPreviewSHA = getenv('TUGBOAT_PREVIEW_SHA');


### PR DESCRIPTION

## Description
Fix implicitly nullable parameters in GitHubStatusTrait deprecated in PHP 8.4. Also add PHP 8.4 and 8.5 to the CI matrix.

## Motivation / Context
Fix deprecations and include latest PHP versions in testing.

## Testing Instructions / How This Has Been Tested
CI should pass.

