### PR TITLE
phpcs_ignore_paths key should be an optional array, not required.

### DIFF
--- a/src/Robo/Plugin/Commands/CICommands.php
+++ b/src/Robo/Plugin/Commands/CICommands.php
@@ -2,7 +2,6 @@
 
 namespace Usher\Robo\Plugin\Commands;
 
-use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Robo;
 use Robo\Tasks;
@@ -114,7 +113,7 @@ class CICommands extends Tasks
         );
         $phpcsIgnorePaths = implode(
             separator: ',',
-            array: $this->getRequiredRoboConfigArrayFor(key: 'phpcs_ignore_paths'),
+            array: $this->getOptionalRoboConfigArrayFor(key: 'phpcs_ignore_paths'),
         );
         $phpcsPhpVersion = Robo::config()->get('php_current_version', $this::PHPCS_DEFAULT_PHP_VERSION);
         $twigLintEnabled = Robo::config()->get('twig_lint_enable') ?? true;


### PR DESCRIPTION
## Description
A missing phpcs_ignore_paths configuration key throws an exception. It should be an optional configuration key. This fixes that.

## Motivation / Context
Resolves #106

## Testing Instructions / How This Has Been Tested
Run phpcs (linting tasks) in your project without the phpcs_ignore_paths key.
